### PR TITLE
Close ahko on misfire: hide window when clicking outside or pressing non-hotkey keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ app.ahk (entry point)
 | `meta.ahk` | Single source of truth for app name, version, binary filename, download URL, changelog |
 | `ahko.ahk` | Core logic. Reads `setting.ini`, scans watch folder (2 levels, 16 items max per level), builds item array |
 | `ahko_ui.ahk` | Thin dispatcher: initializes grid view class with GDIp rendering |
-| `ahko_gridview_ui.ahk` | Main UI. Keyboard-driven grid overlay with 16-button layout using GDIp rendering |
+| `ahko_gridview_ui.ahk` | Main UI. Keyboard-driven grid overlay with 16-button layout using GDIp rendering. Includes misfire detection |
 | `ahko_setup_gui.ahk` | Settings GUI: watch folder, hotkey, monitor position, fullscreen toggle, auto-start |
 | `Gdip_All.ahk` | Third-party GDI+ wrapper library for AHK v2 |
 | `isFullScreen.ahk` | Detects fullscreen windows by comparing client rect against monitor bounds |
@@ -97,6 +97,7 @@ app.ahk (entry point)
 3. **Keyboard-centric grid UI** - 16 keys (`1,2,3,q,w,e,a,s,d,4,r,f,z,x,c,v`) mapped to staggered grid; backtick goes up, Esc hides
 4. **Custom icon convention** - `_icon.png` for folder icons, `<name>.png` for item icons, `[key]` filename prefix for key assignment
 5. **Self-updating** - Checks GitHub releases, downloads zip, uses compiled C binary for file extraction
+6. **Misfire detection** - Timer-based mouse click and InputHook keyboard monitoring; auto-hides ahko window on unrelated input
 6. **Git submodule for toolchain** - `ahk-compile-toolset` bundles compiler and runtime
 
 ---

--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ Created with ahk autoupdate [template](https://github.com/Nigh/ahk-autoupdate-te
 ## Changelog
 
 - Remove Native UI mode, only GDIp rendering is supported.
+- Close ahko window automatically when clicking outside or pressing non-hotkey keys (misfire detection).

--- a/ahko_gridview_ui.ahk
+++ b/ahko_gridview_ui.ahk
@@ -301,7 +301,6 @@ class ahko_gridview_class
 	uShow(*) {
 		if (this.HasOwnProp("father_gui")) {
 			this.father_gui.uShow()
-			; SetTimer(this.gridWaitNotActive, 100)
 		}
 		this.Gui.uHide()
 	}
@@ -325,38 +324,83 @@ class ahko_gridview_class
 	Show() {
 		this.subHide()
 		this.grid_gui.uShow()
-		; SetTimer(this.gridWaitNotActive, 100)
+		this._startMisfireDetection()
 	}
 
-	gridWaitNotActive {
-		get {
-			cb() {
-				active_count := 0
-				if (!this.grid_gui.isHide) {
-					active_count += 1
-					if (!WinActive("ahk_id " this.grid_gui.hwnd)) {
-						this.grid_gui.uHide()
-						SetTimer(this.gridWaitNotActive, 0)
-						Return
-					}
-				}
-				For v in this.grid_sub_gui
-				{
-					if (!v.isHide) {
-						active_count += 1
-						if (!WinActive("ahk_id " v.hwnd)) {
-							v.uHide()
-							SetTimer(this.gridWaitNotActive, 0)
-							Return
-						}
-					}
-				}
-				if (!active_count) {
-					SetTimer(this.gridWaitNotActive, 0)
-				}
-			}
-			Return cb
+	_isAnyVisible() {
+		if (!this.grid_gui.isHide)
+			return true
+		For v in this.grid_sub_gui {
+			if (!v.isHide)
+				return true
 		}
+		return false
+	}
+
+	_isAhkoHwnd(hwnd) {
+		if (hwnd == this.grid_gui.Hwnd)
+			return true
+		For v in this.grid_sub_gui {
+			if (hwnd == v.Hwnd)
+				return true
+		}
+		return false
+	}
+
+	_hideAll() {
+		this._stopMisfireDetection()
+		this._subHide()
+		if (!this.grid_gui.isHide) {
+			this.grid_gui.uHide()
+		}
+	}
+
+	_startMisfireDetection() {
+		this._stopMisfireDetection()
+		this._mouseCheckTimer := ObjBindMethod(this, "_checkMouseClick")
+		SetTimer(this._mouseCheckTimer, 50)
+		this._ih := InputHook("L")
+		this._ih.KeyOpt("{All}", "E")
+		this._ih.OnEnd := ObjBindMethod(this, "_onKeyboardInput")
+		this._ih.Start()
+	}
+
+	_stopMisfireDetection() {
+		if (this._mouseCheckTimer) {
+			SetTimer(this._mouseCheckTimer, 0)
+			this._mouseCheckTimer := ""
+		}
+		if (this._ih) {
+			this._ih.Stop()
+			this._ih := ""
+		}
+	}
+
+	_checkMouseClick() {
+		if (!this._isAnyVisible()) {
+			this._stopMisfireDetection()
+			return
+		}
+		if (DllCall("GetAsyncKeyState", "int", 0x01) & 1) {
+			MouseGetPos(, , &winId)
+			if (!this._isAhkoHwnd(winId)) {
+				this._hideAll()
+			}
+		}
+		if (DllCall("GetAsyncKeyState", "int", 0x02) & 1) {
+			MouseGetPos(, , &winId)
+			if (!this._isAhkoHwnd(winId)) {
+				this._hideAll()
+			}
+		}
+	}
+
+	_onKeyboardInput(ih, vk, sc) {
+		if (!this._isAnyVisible()) {
+			this._stopMisfireDetection()
+			return
+		}
+		this._hideAll()
 	}
 }
 

--- a/ahko_gridview_ui.ahk
+++ b/ahko_gridview_ui.ahk
@@ -32,6 +32,7 @@ class ahko_gridview_class
 	item_map := Map()
 	_mouseCheckTimer := ""
 	_ih := ""
+	_skipMisfireCount := 0
 
 	__New() {
 		for k, v in this.item_pos {
@@ -138,6 +139,7 @@ class ahko_gridview_class
 		uShow(*) {
 			g.isHide := False
 			g.Show(this.gui_showat() " NA")
+			this._skipMisfireCount := 2
 		}
 		g.btnCall := []
 		g.isHide := True
@@ -220,6 +222,7 @@ class ahko_gridview_class
 	{
 		callback_maker() {
 			callback(*) {
+				this._skipMisfireCount := 2
 				guiobj.uHide()
 				if (sub_grid != "" && InStr(ahko_obj.attrib, "D")) {
 					sub_grid.uShow()
@@ -382,6 +385,12 @@ class ahko_gridview_class
 	_checkMouseClick() {
 		if (!this._isAnyVisible()) {
 			this._stopMisfireDetection()
+			return
+		}
+		if (this._skipMisfireCount > 0) {
+			this._skipMisfireCount -= 1
+			DllCall("GetAsyncKeyState", "int", 0x01)
+			DllCall("GetAsyncKeyState", "int", 0x02)
 			return
 		}
 		if (DllCall("GetAsyncKeyState", "int", 0x01) & 1) {

--- a/ahko_gridview_ui.ahk
+++ b/ahko_gridview_ui.ahk
@@ -30,6 +30,8 @@ class ahko_gridview_class
 	gmargin := 10
 	titleHeight := 42
 	item_map := Map()
+	_mouseCheckTimer := ""
+	_ih := ""
 
 	__New() {
 		for k, v in this.item_pos {
@@ -371,6 +373,7 @@ class ahko_gridview_class
 			this._mouseCheckTimer := ""
 		}
 		if (this._ih) {
+			this._ih.OnEnd := ""
 			this._ih.Stop()
 			this._ih := ""
 		}
@@ -395,7 +398,7 @@ class ahko_gridview_class
 		}
 	}
 
-	_onKeyboardInput(ih, vk, sc) {
+	_onKeyboardInput(ih, vk := 0, sc := 0) {
 		if (!this._isAnyVisible()) {
 			this._stopMisfireDetection()
 			return


### PR DESCRIPTION
## Summary
- Detect misfire: when ahko window is visible and user clicks outside or presses non-hotkey keys, automatically close the window
- Uses timer-based mouse click detection via GetAsyncKeyState
- Uses InputHook low-level keyboard hook to detect non-hotkey input
- Replaces the old gridWaitNotActive timer-based approach
- Update README with changelog entry