### PR TITLE
fix: polish setup GUI — larger titles, prominent hotkey text, square close button, timer-based hover

### DIFF
--- a/.kilo/plans/fix-misfire-grid-transition.md
+++ b/.kilo/plans/fix-misfire-grid-transition.md
@@ -1,0 +1,107 @@
+# Fix: Misfire detection false positive on grid transition
+
+## Bug Summary
+
+When clicking a folder button in the main grid to enter a sub-grid, the misfire timer detects the same click as "outside ahko" and closes the window.
+
+## Root Cause
+
+The button click callback (`gui_add_grid_btn` line 222) runs **synchronously** and hides the main grid + shows the sub-grid. The 50ms misfire timer fires **after** this transition. At that point:
+
+1. `GetAsyncKeyState(0x01) & 1` returns true — the mouse was pressed since the last timer call
+2. `MouseGetPos` resolves to the window **behind** ahko — the sub-grid's transparent background (`00FF00` + `WinSetTransColor 220`) is click-through
+3. `!_isAhkoHwnd(winId)` → true → `_hideAll()` fires — false positive
+
+## Fix Plan
+
+Add a `_skipMisfireCount` counter. Grid transitions set this counter. The timer checks/decrements it first; if > 0, it **consumes `GetAsyncKeyState` flags** (to clear the "was pressed" bit) and returns without acting.
+
+### Critical detail: `GetAsyncKeyState` flag consumption
+
+`GetAsyncKeyState(hWnd) & 1` returns whether the key was pressed **since the last call**. The bit is cleared on call. If we simply `return` during the skip window without calling `GetAsyncKeyState`, the "was pressed" bit from the original click **persists** and triggers a false positive after the skip window ends. The fix must call `GetAsyncKeyState` during the skip to consume the stale flag.
+
+### File: `ahko_gridview_ui.ahk`
+
+1. **Add property declaration** (after line 34):
+   ```ahk
+   _skipMisfireCount := 0
+   ```
+
+2. **Modify `_checkMouseClick`** (line 382) — add skip logic that consumes flags:
+   ```ahk
+   _checkMouseClick() {
+       if (!this._isAnyVisible()) {
+           this._stopMisfireDetection()
+           return
+       }
+       if (this._skipMisfireCount > 0) {
+           this._skipMisfireCount -= 1
+           DllCall("GetAsyncKeyState", "int", 0x01)
+           DllCall("GetAsyncKeyState", "int", 0x02)
+           return
+       }
+       if (DllCall("GetAsyncKeyState", "int", 0x01) & 1) {
+           MouseGetPos(, , &winId)
+           if (!this._isAhkoHwnd(winId)) {
+               this._hideAll()
+           }
+       }
+       if (DllCall("GetAsyncKeyState", "int", 0x02) & 1) {
+           MouseGetPos(, , &winId)
+           if (!this._isAhkoHwnd(winId)) {
+               this._hideAll()
+           }
+       }
+   }
+   ```
+
+3. **Set skip in `set_gui_default_prop` `uShow` closure** (line 138) — covers all grid show transitions:
+   ```ahk
+   uShow(*) {
+       g.isHide := False
+       g.Show(this.gui_showat() " NA")
+       this._skipMisfireCount := 2
+   }
+   ```
+   This single change covers: folder-open (`sub_grid.uShow()`), back-to-main (`father_gui.uShow()`), and hotkey-show (`grid_gui.uShow()`).
+
+4. **Set skip in `gui_add_grid_btn` callback** (line 222) — defense-in-depth, set BEFORE the hide:
+   ```ahk
+   callback(*) {
+       this._skipMisfireCount := 2
+       guiobj.uHide()
+       ; ... rest unchanged
+   }
+   ```
+
+### Summary of changes
+
+| Location | Change |
+|----------|--------|
+| Class property (after line 34) | Add `_skipMisfireCount := 0` |
+| `_checkMouseClick` (line 382) | Check/decrement `_skipMisfireCount`, consume `GetAsyncKeyState` flags, return early |
+| `set_gui_default_prop` `uShow` closure (line 138) | Set `this._skipMisfireCount := 2` after show |
+| `gui_add_grid_btn` callback (line 222) | Set `this._skipMisfireCount := 2` before `guiobj.uHide()` |
+
+### Trace: folder button click (main → sub)
+
+1. `Show()` → main grid visible, `_startMisfireDetection()` starts 50ms timer
+2. User clicks folder button → `Click` event fires callback
+3. Callback: `this._skipMisfireCount := 2`, `guiobj.uHide()`, `sub_grid.uShow()` (also sets `_skipMisfireCount := 2`)
+4. Timer tick 1: `_skipMisfireCount = 2 > 0` → decrement to 1, consume `GetAsyncKeyState` flags, return
+5. Timer tick 2: `_skipMisfireCount = 1 > 0` → decrement to 0, consume `GetAsyncKeyState` flags, return
+6. Timer tick 3: `_skipMisfireCount = 0` → `GetAsyncKeyState(0x01) & 1` → 0 (flags consumed, user released) → no false positive
+
+### Trace: title back button (sub → main)
+
+1. User clicks title button on sub-grid → `uShow` class method fires
+2. `this.father_gui.uShow()` → closure sets `_skipMisfireCount := 2`, shows main grid
+3. `this.Gui.uHide()` → hides sub-grid
+4. Timer ticks: same as above — flags consumed during skip, no false positive
+
+### Why this is safe
+
+- `_skipMisfireCount` only skips mouse-based detection; keyboard InputHook is unaffected
+- The skip window (100ms = 2×50ms ticks) is long enough for click release but short enough to not mask real misfires
+- `GetAsyncKeyState` is called during skip to consume stale "was pressed" flags
+- Setting skip in both `uShow` closure and button callback covers all transition paths

--- a/.kilo/plans/fix-setup-gui-polish.md
+++ b/.kilo/plans/fix-setup-gui-polish.md
@@ -1,0 +1,54 @@
+# Fix Setup GUI: title font, hotkey text, close button shape, hover effects
+
+## Problems
+
+1. **Section title font too small** — "Watch Folder", "Hotkey", "Display Location", "Other" use `s14` GDI+ text, visually too small on the dark panel.
+2. **Hotkey result text not prominent** — `ahkoSetup_hotkeyText` is `s10 w600` on a `+BackgroundTrans` Text control with `c89B4FA`. Low contrast and small.
+3. **Close button should be square** — Currently drawn with `radius=16` (fully rounded circle). Needs square shape with small radius (e.g. 4).
+4. **Hover effects broken** — `setup_WM_MOUSEMOVE` never fires when mouse is over child controls (Edit, Hotkey, DDL, CheckBox, Picture). Windows sends `WM_MOUSEMOVE` to the child control under the cursor, not the parent GUI. The `OnMessage(0x0200, ...)` handler is bypassed entirely.
+
+## Solution
+
+### Fix 1: Section title font size
+- Change `s14` to `s16` in all section title `Gdip_TextToGraphics` calls in `setup_renderBg()` (lines 202, 211, 227, 236)
+- Increase the label height allocation from 24 to 28 in the GDI+ draw calls
+- Adjust `setup_posY_*` spacing if needed to prevent overlap
+
+### Fix 2: Hotkey result text
+- Change `ahkoSetup_hotkeyText` from `s10 w600` to `s13 w700` (line 87)
+- Increase height from 22 to 26
+- Use brighter accent color `clrAccentHover` (0xFFB4D0FB) instead of `c89B4FA` for more visibility
+
+### Fix 3: Close button square shape
+- In `setup_renderButtons()` line 168: change `setup_makeBtnBitmap(32, 32, "X", closeBg, closeTxtColor, 13, 16)` — change `16` (radius) to `4`
+
+### Fix 4: Hover via timer (replacing broken WM_MOUSEMOVE)
+The root cause: child controls (Edit, Hotkey, DDL, CheckBox, Picture) intercept `WM_MOUSEMOVE` before the parent GUI sees it. The `OnMessage(0x0200, ...)` handler never fires when mouse is over any child.
+
+**Fix:** Replace `OnMessage(0x0200, ...)` with a `SetTimer` that polls mouse position every 30ms using `GetCursorPos` + `WindowFromPoint`. This is the same pattern used by `ahko_gridview_ui.ahk` for its misfire detection (line 363-366).
+
+Changes:
+- Remove `OnMessage(0x0200, setup_WM_MOUSEMOVE)` and `OnMessage(0x02A3, setup_WM_MOUSELEAVE)`
+- Remove `setup_WM_MOUSEMOVE` and `setup_WM_MOUSELEAVE` functions
+- Remove `setup_trackMouseEvent` function
+- Add `setup_hoverTimer` — a `SetTimer` callback that:
+  1. Gets cursor screen pos via `GetCursorPos`
+  2. Gets window pos via `WinGetPos`
+  3. Converts to client coords
+  4. Calls `setup_hitTest(mx, my)`
+  5. If hover state changed, calls `setup_renderButtons()` and updates cursor
+  6. If cursor left the window entirely, resets to `hover_none`
+- Start timer in `ahko_setup_show()`, stop in `ahko_setup_cancel()` / `ahko_setup_save()`
+- Keep `OnMessage(0x0201, setup_WM_LBUTTONDOWN)` for drag (this one works because it's handled before child controls)
+
+## Files to modify
+- `ahko_setup_gui.ahk` — all 4 fixes in this single file
+
+## Verification
+- Run `AutoHotkey64.exe app.ahk`, trigger setup via tray
+- Verify section titles are clearly readable at `s16`
+- Verify hotkey result text is large and bright
+- Verify close button is square
+- Verify hover effects work on Select, Save, Cancel, Close buttons
+- Verify drag still works on title bar
+- Verify all native controls still function (Edit, Hotkey, DDL, CheckBox)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ app.ahk (entry point)
 | `ahko.ahk` | Core logic. Reads `setting.ini`, scans watch folder (2 levels, 16 items max per level), builds item array |
 | `ahko_ui.ahk` | Thin dispatcher: initializes grid view class with GDIp rendering |
 | `ahko_gridview_ui.ahk` | Main UI. Keyboard-driven grid overlay with 16-button layout using GDIp rendering. Includes misfire detection |
-| `ahko_setup_gui.ahk` | Settings GUI: watch folder, hotkey, monitor position, fullscreen toggle, auto-start |
+| `ahko_setup_gui.ahk` | Settings GUI: borderless window with GDIp-rendered header, buttons, and section labels. Uses native controls for inputs. Watch folder, hotkey, monitor position, fullscreen toggle, auto-start. Timer-based hover detection via `SetTimer` + `GetCursorPos` polling (30ms) |
 | `Gdip_All.ahk` | Third-party GDI+ wrapper library for AHK v2 |
 | `isFullScreen.ahk` | Detects fullscreen windows by comparing client rect against monitor bounds |
 | `tray.ahk` | System tray context menu: version, Setup, GitHub, Donate, Reload, Exit |
@@ -98,7 +98,8 @@ app.ahk (entry point)
 4. **Custom icon convention** - `_icon.png` for folder icons, `<name>.png` for item icons, `[key]` filename prefix for key assignment
 5. **Self-updating** - Checks GitHub releases, downloads zip, uses compiled C binary for file extraction
 6. **Misfire detection** - Timer-based mouse click and InputHook keyboard monitoring; auto-hides ahko window on unrelated input
-6. **Git submodule for toolchain** - `ahk-compile-toolset` bundles compiler and runtime
+7. **GDIp setup GUI** - Borderless setup window with GDIp-rendered header (dark title bar, rounded close button), GDIp-drawn buttons (Save, Cancel, Select), and native controls for text inputs. Draggable via WM_NCLBUTTONDOWN on header area
+8. **Git submodule for toolchain** - `ahk-compile-toolset` bundles compiler and runtime
 
 ---
 
@@ -149,7 +150,7 @@ No formal testing or linting framework is present. The project relies on manual 
 ## Git Information
 
 - **Main branch:** `ahk` (active development)
-- **Other branches:** `main`, `rust` (Tauri rewrite), `web-gui`, `gdip-gui`, `null-callback-fix`
+- **Other branches:** `main`, `rust` (Tauri rewrite), `web-gui`, `gdip-gui`, `gdip-setup-gui`, `null-callback-fix`
 - **Tags:** `v0.0.1` through `v1.0.3`
 - **Submodule:** `ahk-compile-toolset` from `https://github.com/Nigh/ahk-compile-toolset`
 

--- a/ahko_setup_gui.ahk
+++ b/ahko_setup_gui.ahk
@@ -1,54 +1,273 @@
-h2FontStyle := "s18 w600 c505050 q5"
-textFontStyle := "s12 w400 cblack q5"
-clientWidth := 360
-header_gap := " y+10 "
-item_gap := " y+3 "
+setup_winW := 540
+setup_winH := 620
+setup_margin := 28
+setup_inputH := 36
+setup_radius := 10
+setup_font := "Microsoft JhengHei"
 
-ahko_setup := Gui("+ToolWindow +AlwaysOnTop -DPIScale +OwnDialogs", "ahko setup")
-ahko_setup.SetFont(, "Consolas")
-ahko_setup.SetFont(, "MV Boli")
-ahko_setup.SetFont(, "Comic Sans MS")
+clrBg := 0xFF11111B
+clrPanel := 0xFF1E1E2E
+clrHeader := 0xFF181825
+clrAccent := 0xFF89B4FA
+clrAccentHover := 0xFFB4D0FB
+clrTextPri := 0xFFCDD6F4
+clrTextSec := 0xFF6C7086
+clrTextInv := 0xFF1E1E2E
+clrSurface := 0xFF313244
+clrSurfaceHover := 0xFF45475A
+clrInputBg := 0xFF313244
+clrInputBorder := 0xFF45475A
+clrBtnSave := 0xFF89B4FA
+clrBtnSaveHover := 0xFFB4D0FB
+clrBtnCancel := 0xFF313244
+clrBtnCancelHover := 0xFF45475A
+clrBtnCancelText := 0xFFCDD6F4
+clrCloseBtn := 0xFF45475A
+clrCloseBtnHover := 0xFFF38BA8
+clrDivider := 0xFF313244
 
-ahko_setup.SetFont("s32 w700 cc07070")
-ahko_setup.Add("Text", "x25 y5", "Setup")
-ahko_setup.Add("Text", "x0 y+-66 +BackgroundTrans", "________")
+setup_headerH := 68
 
-ahko_setup.SetFont(h2FontStyle)
-ahko_setup.Add("Text", "xs " header_gap, "Watch folder")
-ahko_setup.SetFont(textFontStyle)
-buttonWidth := 95
-AhkoSetup_path := ahko_setup.Add("Edit", item_gap "r1 w" clientWidth - buttonWidth - 5, "")
-pathSelectBtn := ahko_setup.Add("Button", "x+5 hp w" buttonWidth, "Select")
-pathSelectBtn.OnEvent("Click", setup_path)
-setup_path(*) {
-	global AhkoSetup_path, ahko_setup
-	ahko_setup.Opt("+OwnDialogs")
-	newpath := RegExReplace(DirSelect(, 0), "\\$")
-	ahkoSetup_path.Value := newpath
-}
+setup_posY_watchLabel := setup_headerH + 22
+setup_posY_pathInput := setup_posY_watchLabel + 28
+setup_posY_hotkeyLabel := setup_posY_pathInput + setup_inputH + 22
+setup_posY_hotkeyInput := setup_posY_hotkeyLabel + 28
+setup_posY_hotkeyText := setup_posY_hotkeyInput + setup_inputH + 8
+setup_posY_showAtLabel := setup_posY_hotkeyText + 22 + 20
+setup_posY_showAtDDL := setup_posY_showAtLabel + 28
+setup_posY_otherLabel := setup_posY_showAtDDL + setup_inputH + 24
+setup_posY_fullscreen := setup_posY_otherLabel + 28
+setup_posY_autoStart := setup_posY_fullscreen + 34
+setup_posY_buttons := setup_posY_autoStart + 34 + 36
 
-ahko_setup.SetFont(h2FontStyle)
-ahko_setup.Add("Text", "xs " header_gap, "Hotkey")
-ahko_setup.SetFont(textFontStyle)
-ahkoSetup_hotkey := ahko_setup.Add("Hotkey", item_gap "w" clientWidth - buttonWidth - 5)
-ahkoSetup_hotkey.OnEvent("Change", hotkeyText_update)
-ahkoSetup_hotkeyWin := ahko_setup.Add("CheckBox", "x+10 hp w" buttonWidth, "Win")
-ahkoSetup_hotkeyWin.OnEvent("Click", hotkeyText_update)
+setup_pathBtnX := setup_winW - setup_margin - 100
+setup_pathBtnW := 100
+setup_hotkeyWinX := setup_winW - setup_margin - 100
+setup_hotkeyWinW := 100
+setup_inputW := setup_winW - setup_margin * 2 - 110
+setup_ddlW := setup_winW - setup_margin * 2
+setup_ctrlX := setup_margin
 
-ahko_setup.SetFont("s10")
-ahko_setup.Add("Text", "xs" item_gap, "Hotkey is ")
-ahkoSetup_hotkeyText := ahko_setup.Add("Text", "x+0 hp cc07070 w260", "")
+setup_saveBtnX := setup_margin
+setup_saveBtnY := setup_posY_buttons
+setup_saveBtnW := (setup_winW - setup_margin * 2 - 20) // 2
+setup_saveBtnH := 44
+setup_cancelBtnX := setup_saveBtnX + setup_saveBtnW + 20
+setup_cancelBtnY := setup_posY_buttons
+setup_cancelBtnW := setup_saveBtnW
+setup_cancelBtnH := 44
 
-ahko_setup.SetFont(h2FontStyle)
-ahko_setup.Add("Text", "xs " header_gap, "ahko where")
-ahko_setup.SetFont(textFontStyle)
+hover_none := 0
+hover_sel := 1
+hover_save := 2
+hover_cancel := 3
+hover_close := 4
+setup_hoverState := hover_none
+
+ahko_setup := Gui("-Caption +ToolWindow +AlwaysOnTop -DPIScale +OwnDialogs")
+ahko_setup.BackColor := "11111B"
+ahko_setup.MarginX := 0
+ahko_setup.MarginY := 0
+
+setup_picBg := ahko_setup.Add("Picture", "x0 y0 w" setup_winW " h" setup_winH " 0xE +BackgroundTrans")
+
+ahkoSetup_path := ahko_setup.Add("Edit", "x" setup_ctrlX " y" setup_posY_pathInput " w" setup_inputW " h" setup_inputH " -E0x200 -Border Background313244 cCDD6F4")
+ahkoSetup_path.SetFont("s11", setup_font)
+
+setup_picSel := ahko_setup.Add("Picture", "x" setup_pathBtnX " y" setup_posY_pathInput " w" setup_pathBtnW " h" setup_inputH " 0xE +BackgroundTrans")
+setup_picSel.OnEvent("Click", setup_path)
+
+ahkoSetup_hotkey := ahko_setup.Add("Hotkey", "x" setup_ctrlX " y" setup_posY_hotkeyInput " w" setup_inputW " h" setup_inputH " -E0x200")
+ahkoSetup_hotkey.SetFont("s11 cCDD6F4", setup_font)
+
+ahkoSetup_hotkeyWin := ahko_setup.Add("CheckBox", "x" setup_hotkeyWinX " y" setup_posY_hotkeyInput " w" setup_hotkeyWinW " h" setup_inputH " -E0x200 Background313244 cCDD6F4", "Win")
+ahkoSetup_hotkeyWin.SetFont("s11", setup_font)
+
+ahkoSetup_hotkeyText := ahko_setup.Add("Text", "x" setup_ctrlX " y" setup_posY_hotkeyText " w" setup_ddlW " h" 26 " +BackgroundTrans cB4D0FB")
+ahkoSetup_hotkeyText.SetFont("s13 w700", setup_font)
+
 showAtDDL := ["Primary monitor", "Follow mouse", "Follow active window"]
 For k_ddl, v_ddl in isFullScreen.monitors
 {
 	showAtDDL.Push("Monitor #" k_ddl)
 }
-ahkoSetup_showAt := ahko_setup.Add("DropDownList", item_gap "w" clientWidth, showAtDDL)
+ahkoSetup_showAt := ahko_setup.Add("DropDownList", "x" setup_ctrlX " y" setup_posY_showAtDDL " w" setup_ddlW " h" 220 " -E0x200", showAtDDL)
+ahkoSetup_showAt.SetFont("s11 cCDD6F4", setup_font)
+
+ahkoSetup_enable_fullscreen := ahko_setup.Add("CheckBox", "x" setup_ctrlX " y" setup_posY_fullscreen " w" setup_ddlW " h" 28 " -E0x200 Background1E1E2E cCDD6F4", "Enable in fullscreen")
+ahkoSetup_enable_fullscreen.SetFont("s11", setup_font)
+
+ahkoSetup_autoStart := ahko_setup.Add("CheckBox", "x" setup_ctrlX " y" setup_posY_autoStart " w" setup_ddlW " h" 28 " -E0x200 Background1E1E2E cCDD6F4", "Startup with Windows")
+ahkoSetup_autoStart.SetFont("s11", setup_font)
+
+setup_picSave := ahko_setup.Add("Picture", "x" setup_saveBtnX " y" setup_saveBtnY " w" setup_saveBtnW " h" setup_saveBtnH " 0xE +BackgroundTrans")
+setup_picCancel := ahko_setup.Add("Picture", "x" setup_cancelBtnX " y" setup_cancelBtnY " w" setup_cancelBtnW " h" setup_cancelBtnH " 0xE +BackgroundTrans")
+setup_picClose := ahko_setup.Add("Picture", "x" setup_winW - 48 " y" 18 " w" 32 " h" 32 " 0xE +BackgroundTrans")
+
+setup_picSave.OnEvent("Click", ahko_setup_save)
+setup_picCancel.OnEvent("Click", ahko_setup_cancel)
+setup_picClose.OnEvent("Click", ahko_setup_cancel)
+ahkoSetup_hotkey.OnEvent("Change", hotkeyText_update)
+ahkoSetup_hotkeyWin.OnEvent("Click", hotkeyText_update)
 ahkoSetup_showAt.OnEvent("Change", showAt_update)
+ahkoSetup_enable_fullscreen.OnEvent("Click", enable_fullscreen_update)
+ahkoSetup_autoStart.OnEvent("Click", autoStartup_update)
+
+OnMessage(0x0201, setup_WM_LBUTTONDOWN)
+
+setup_btnHitAreas := Map()
+setup_btnHitAreas[hover_sel] := { x: setup_pathBtnX, y: setup_posY_pathInput, w: setup_pathBtnW, h: setup_inputH }
+setup_btnHitAreas[hover_save] := { x: setup_saveBtnX, y: setup_saveBtnY, w: setup_saveBtnW, h: setup_saveBtnH }
+setup_btnHitAreas[hover_cancel] := { x: setup_cancelBtnX, y: setup_cancelBtnY, w: setup_cancelBtnW, h: setup_cancelBtnH }
+setup_btnHitAreas[hover_close] := { x: setup_winW - 48, y: 18, w: 32, h: 32 }
+
+setup_pic_show(ctrl, pBitmap) {
+	hBitmap := Gdip_CreateHBITMAPFromBitmap(pBitmap)
+	SetImage(ctrl.Hwnd, hBitmap)
+	DeleteObject(hBitmap)
+}
+
+setup_drawBtn(pGraphics, x, y, w, h, text, bgColor, textColor, fontSize := 12, radius := 8) {
+	pBrush := Gdip_BrushCreateSolid(bgColor)
+	Gdip_FillRoundedRectangle(pGraphics, pBrush, x, y, w, h, radius)
+	Gdip_DeleteBrush(pBrush)
+	Gdip_TextToGraphics(pGraphics, text, "x" x " y" y " w" w " h" h " c" Format("{:08X}", textColor) " s" fontSize " Center vCenter R4", setup_font)
+}
+
+setup_makeBtnBitmap(w, h, text, bgColor, textColor, fontSize := 12, radius := 8) {
+	pBitmap := Gdip_CreateBitmap(w, h)
+	G := Gdip_GraphicsFromImage(pBitmap)
+	Gdip_SetSmoothingMode(G, 4)
+	pBrush := Gdip_BrushCreateSolid(bgColor)
+	Gdip_FillRoundedRectangle(G, pBrush, 0, 0, w, h, radius)
+	Gdip_DeleteBrush(pBrush)
+	Gdip_TextToGraphics(G, text, "x0 y0 w" w " h" h " c" Format("{:08X}", textColor) " s" fontSize " Center vCenter R4", setup_font)
+	Gdip_DeleteGraphics(G)
+	return pBitmap
+}
+
+setup_renderButtons() {
+	global
+
+	pBmpSel := setup_makeBtnBitmap(setup_pathBtnW, setup_inputH, "Select", (setup_hoverState == hover_sel) ? clrAccentHover : clrAccent, clrTextInv, 11, 6)
+	setup_pic_show(setup_picSel, pBmpSel)
+	Gdip_DisposeImage(pBmpSel)
+
+	pBmpSave := setup_makeBtnBitmap(setup_saveBtnW, setup_saveBtnH, "Save", (setup_hoverState == hover_save) ? clrBtnSaveHover : clrBtnSave, clrTextInv, 14, 8)
+	setup_pic_show(setup_picSave, pBmpSave)
+	Gdip_DisposeImage(pBmpSave)
+
+	pBmpCancel := setup_makeBtnBitmap(setup_cancelBtnW, setup_cancelBtnH, "Cancel", (setup_hoverState == hover_cancel) ? clrBtnCancelHover : clrBtnCancel, clrBtnCancelText, 14, 8)
+	setup_pic_show(setup_picCancel, pBmpCancel)
+	Gdip_DisposeImage(pBmpCancel)
+
+	closeBg := (setup_hoverState == hover_close) ? clrCloseBtnHover : clrCloseBtn
+	closeTxtColor := (setup_hoverState == hover_close) ? clrTextPri : clrTextSec
+	pBmpClose := setup_makeBtnBitmap(32, 32, "X", closeBg, closeTxtColor, 13, 4)
+	setup_pic_show(setup_picClose, pBmpClose)
+	Gdip_DisposeImage(pBmpClose)
+}
+
+setup_renderBg() {
+	global
+
+	pBitmap := Gdip_CreateBitmap(setup_winW, setup_winH)
+	G := Gdip_GraphicsFromImage(pBitmap)
+	Gdip_SetSmoothingMode(G, 4)
+	Gdip_SetInterpolationMode(G, 7)
+
+	pBrushBg := Gdip_BrushCreateSolid(clrBg)
+	Gdip_FillRectangle(G, pBrushBg, 0, 0, setup_winW, setup_winH)
+	Gdip_DeleteBrush(pBrushBg)
+
+	pBrushPanel := Gdip_BrushCreateSolid(clrPanel)
+	Gdip_FillRoundedRectangle(G, pBrushPanel, 0, 0, setup_winW, setup_winH, setup_radius)
+	Gdip_DeleteBrush(pBrushPanel)
+
+	pBrushHeader := Gdip_BrushCreateSolid(clrHeader)
+	Gdip_FillRoundedRectangle(G, pBrushHeader, 0, 0, setup_winW, setup_headerH, setup_radius)
+	Gdip_DeleteBrush(pBrushHeader)
+	pBrushHeaderFill := Gdip_BrushCreateSolid(clrHeader)
+	Gdip_FillRectangle(G, pBrushHeaderFill, 0, setup_headerH - setup_radius, setup_winW, setup_radius)
+	Gdip_DeleteBrush(pBrushHeaderFill)
+
+	Gdip_TextToGraphics(G, "ahko Setup", "x24 y16 w300 h40 c" Format("{:08X}", clrTextPri) " s22 Bold R4", setup_font)
+
+	pPenDiv := Gdip_CreatePen(clrDivider, 1)
+	Gdip_DrawLine(G, pPenDiv, setup_margin, setup_headerH + 1, setup_winW - setup_margin, setup_headerH + 1)
+	Gdip_DeletePen(pPenDiv)
+
+	Gdip_TextToGraphics(G, "Watch Folder", "x" setup_ctrlX " y" setup_posY_watchLabel " w300 h28 c" Format("{:08X}", clrTextPri) " s16 Bold R4", setup_font)
+
+	pBrushInput := Gdip_BrushCreateSolid(clrInputBg)
+	Gdip_FillRoundedRectangle(G, pBrushInput, setup_ctrlX, setup_posY_pathInput, setup_inputW, setup_inputH, 6)
+	Gdip_DeleteBrush(pBrushInput)
+	pPenInput := Gdip_CreatePen(clrInputBorder, 1)
+	Gdip_DrawRoundedRectangle(G, pPenInput, setup_ctrlX, setup_posY_pathInput, setup_inputW, setup_inputH, 6)
+	Gdip_DeletePen(pPenInput)
+
+	Gdip_TextToGraphics(G, "Hotkey", "x" setup_ctrlX " y" setup_posY_hotkeyLabel " w200 h28 c" Format("{:08X}", clrTextPri) " s16 Bold R4", setup_font)
+
+	pBrushInput2 := Gdip_BrushCreateSolid(clrInputBg)
+	Gdip_FillRoundedRectangle(G, pBrushInput2, setup_ctrlX, setup_posY_hotkeyInput, setup_inputW, setup_inputH, 6)
+	Gdip_DeleteBrush(pBrushInput2)
+	pPenInput2 := Gdip_CreatePen(clrInputBorder, 1)
+	Gdip_DrawRoundedRectangle(G, pPenInput2, setup_ctrlX, setup_posY_hotkeyInput, setup_inputW, setup_inputH, 6)
+	Gdip_DeletePen(pPenInput2)
+
+	pBrushWin := Gdip_BrushCreateSolid(clrSurface)
+	Gdip_FillRoundedRectangle(G, pBrushWin, setup_hotkeyWinX, setup_posY_hotkeyInput, setup_hotkeyWinW, setup_inputH, 6)
+	Gdip_DeleteBrush(pBrushWin)
+	pPenWin := Gdip_CreatePen(clrInputBorder, 1)
+	Gdip_DrawRoundedRectangle(G, pPenWin, setup_hotkeyWinX, setup_posY_hotkeyInput, setup_hotkeyWinW, setup_inputH, 6)
+	Gdip_DeletePen(pPenWin)
+
+	Gdip_TextToGraphics(G, "Display Location", "x" setup_ctrlX " y" setup_posY_showAtLabel " w300 h28 c" Format("{:08X}", clrTextPri) " s16 Bold R4", setup_font)
+
+	pBrushDDL := Gdip_BrushCreateSolid(clrInputBg)
+	Gdip_FillRoundedRectangle(G, pBrushDDL, setup_ctrlX, setup_posY_showAtDDL, setup_ddlW, setup_inputH, 6)
+	Gdip_DeleteBrush(pBrushDDL)
+	pPenDDL := Gdip_CreatePen(clrInputBorder, 1)
+	Gdip_DrawRoundedRectangle(G, pPenDDL, setup_ctrlX, setup_posY_showAtDDL, setup_ddlW, setup_inputH, 6)
+	Gdip_DeletePen(pPenDDL)
+
+	Gdip_TextToGraphics(G, "Other", "x" setup_ctrlX " y" setup_posY_otherLabel " w200 h28 c" Format("{:08X}", clrTextPri) " s16 Bold R4", setup_font)
+
+	Gdip_TextToGraphics(G, "github.com/Nigh/ahko", "x" setup_ctrlX " y" setup_winH - 28 " w" setup_ddlW " h20 c" Format("{:08X}", clrTextSec) " s9 Right R4", "Segoe UI")
+
+	setup_pic_show(setup_picBg, pBitmap)
+	Gdip_DeleteGraphics(G)
+	Gdip_DisposeImage(pBitmap)
+}
+
+setup_path(*) {
+	global ahkoSetup_path, ahko_setup
+	ahko_setup.Opt("+OwnDialogs")
+	newpath := RegExReplace(DirSelect(, 0), "\\$")
+	if (newpath != "") {
+		ahkoSetup_path.Value := newpath
+	}
+}
+
+hotkeyText_update(*) {
+	global
+	local hotkey_str := ""
+	if (ahkoSetup_hotkeyWin.Value) {
+		hotkey_str .= "Win + "
+	}
+	if (InStr(ahkoSetup_hotkey.Value, "^")) {
+		hotkey_str .= "Ctrl + "
+	}
+	if (InStr(ahkoSetup_hotkey.Value, "!")) {
+		hotkey_str .= "Alt + "
+	}
+	if (InStr(ahkoSetup_hotkey.Value, "+")) {
+		hotkey_str .= "Shift + "
+	}
+	hotkey_str .= RegExReplace(ahkoSetup_hotkey.Value, "#|\^|\!|\+|\<|\>")
+	ahkoSetup_hotkeyText.Value := hotkey_str
+}
+
 showat_from_ddl(dd) {
 	if (dd >= 4) {
 		return dd - 3
@@ -82,7 +301,6 @@ ddl_from_showat(sw) {
 }
 showAt_update(*) {
 	global showat
-	; MsgBox(ahkoSetup_showAt.Value)
 	if (ahkoSetup_showAt.Value >= 4) {
 		showat := showat_from_ddl(ahkoSetup_showAt.Value)
 		ahko_setup.Show(showat_monitor(showat))
@@ -91,52 +309,15 @@ showAt_update(*) {
 	}
 	showat_monitor(n) {
 		global isFullScreen, ahko_setup
-		ahko_setup.GetClientPos(, , &w, &h)
+		ahko_setup.GetPos(, , &w, &h)
 		Return "x" Round(isFullScreen.monitors[n].l + isFullScreen.monitors[n].r - w) // 2 " y" Round(isFullScreen.monitors[n].t + isFullScreen.monitors[n].b - h) // 2
 	}
 }
 
-ahko_setup.SetFont(h2FontStyle)
-ahko_setup.Add("Text", "xs " header_gap, "Other")
-ahko_setup.SetFont(textFontStyle)
-ahkoSetup_enable_fullscreen := ahko_setup.Add("CheckBox", "y+-5 hp", "Enable in fullscreen")
-ahkoSetup_enable_fullscreen.OnEvent("Click", enable_fullscreen_update)
-
-ahkoSetup_autoStart := ahko_setup.Add("CheckBox", "y+-10 hp", "Startup with Windows")
-ahkoSetup_autoStart.OnEvent("Click", autoStartup_update)
-
-ahko_setup.SetFont(textFontStyle)
-saveBtn := ahko_setup.Add("Button", "xs y+30 h50 w" (clientWidth - 40) // 2, "Save")
-saveBtn.OnEvent("Click", ahko_setup_save)
-cancelBtn := ahko_setup.Add("Button", "x+40 hp w" (clientWidth - 40) // 2, "Cancel")
-cancelBtn.OnEvent("Click", ahko_setup_cancel)
-
-ahko_setup.Add("Link", "xs y+0 w" clientWidth " right", 'Visit <a href="https://github.com/Nigh/ahko">GitHub Page</a>')
-
-hotkeyText_update(*) {
-	global
-
-	local hotkey_str := ""
-	if (ahkoSetup_hotkeyWin.Value) {
-		hotkey_str .= "Win + "
-	}
-	if (InStr(ahkoSetup_hotkey.Value, "^")) {
-		hotkey_str .= "Ctrl + "
-	}
-	if (InStr(ahkoSetup_hotkey.Value, "!")) {
-		hotkey_str .= "Alt + "
-	}
-	if (InStr(ahkoSetup_hotkey.Value, "+")) {
-		hotkey_str .= "Shift + "
-	}
-	hotkey_str .= RegExReplace(ahkoSetup_hotkey.Value, "#|\^|\!|\+|\<|\>")
-	ahkoSetup_hotkeyText.Value := hotkey_str
-}
 ahko_setup_show(*) {
 	global
 	ahkoSetup_showAt.Value := ddl_from_showat(showat)
 	ahkoSetup_path.Value := path
-
 	ahkoSetup_hotkey.Value := RegExReplace(hotkeys, "#")
 	ahkoSetup_hotkeyWin.Value := RegExMatch(hotkeys, "#")
 	hotkeyText_update()
@@ -147,18 +328,23 @@ ahko_setup_show(*) {
 	} else {
 		ahkoSetup_autoStart.Value := 0
 	}
-	ahko_setup.show("w" clientWidth + 60)
+	setup_hoverState := hover_none
+	setup_renderBg()
+	setup_renderButtons()
+	ahko_setup.Show("w" setup_winW " h" setup_winH " NA")
+	SetTimer(setup_hoverTick, 30)
 }
+
 ahko_setup_cancel(*) {
 	global
+	SetTimer(setup_hoverTick, 0)
 	ahko_setup.Hide()
 }
 
-; TODO: 未改动设置时无需重启
 ahko_setup_save(*) {
 	global
-	if (ahko_setup_check())
-	{
+	SetTimer(setup_hoverTick, 0)
+	if (ahko_setup_check()) {
 		hotkeyStr := ""
 		if (ahkoSetup_hotkeyWin.Value) {
 			hotkeyStr := "#"
@@ -168,7 +354,7 @@ ahko_setup_save(*) {
 		IniWrite("key=" hotkeyStr, "setting.ini", "hotkey")
 		IniWrite("fullscreen=" fullscreen_enable, "setting.ini", "hotkey")
 		IniWrite("showat=" showat, "setting.ini", "settings")
-		MsgBox("In order for the changes to take effect`nahko is is about to be restarted", "OK", "Owner" ahko_setup.Hwnd)
+		MsgBox("In order for the changes to take effect`nahko is about to be restarted", "OK", "Owner" ahko_setup.Hwnd)
 		Reload
 	}
 }
@@ -197,20 +383,72 @@ ahko_setup_autostart(b) {
 	if (b) {
 		RunWait('"' A_ScriptFullPath '" /script /force "' A_Temp "\ahko_temp\set_auto_run.ahk" '"' " --name=ahko --target=" A_ScriptFullPath)
 	} else {
-		RunWait('"' A_ScriptFullPath '" /script /force "' A_Temp "\ahko_temp\set_auto_run.ahk" '"' " --name=ahko --remove" )
+		RunWait('"' A_ScriptFullPath '" /script /force "' A_Temp "\ahko_temp\set_auto_run.ahk" '"' " --name=ahko --remove")
 	}
 	try {
 		FileDelete(A_Temp "\ahko_temp\startup.exe")
 	}
 }
-autoStartup_update(*)
-{
+autoStartup_update(*) {
 	global
 	ahko_setup_autostart(ahkoSetup_autoStart.Value)
 }
-enable_fullscreen_update(*)
-{
+enable_fullscreen_update(*) {
 	global
 	fullscreen_enable := ahkoSetup_enable_fullscreen.Value
 }
-; ahko_setup_show()
+
+setup_hitTest(mx, my) {
+	global
+	for id, r in setup_btnHitAreas {
+		if (mx >= r.x && mx < r.x + r.w && my >= r.y && my < r.y + r.h) {
+			return id
+		}
+	}
+	return hover_none
+}
+
+setup_hoverTick() {
+	global
+	if !WinExist("ahk_id " ahko_setup.Hwnd) {
+		return
+	}
+	pt := Buffer(8, 0)
+	DllCall("GetCursorPos", "Ptr", pt)
+	sx := NumGet(pt, 0, "Int")
+	sy := NumGet(pt, 4, "Int")
+	WinGetPos(&wx, &wy, &ww, &wh, "ahk_id " ahko_setup.Hwnd)
+	mx := sx - wx
+	my := sy - wy
+	if (mx < 0 || my < 0 || mx >= ww || my >= wh) {
+		if (setup_hoverState != hover_none) {
+			setup_hoverState := hover_none
+			setup_renderButtons()
+		}
+		return
+	}
+	newHover := setup_hitTest(mx, my)
+	if (newHover != setup_hoverState) {
+		setup_hoverState := newHover
+		setup_renderButtons()
+	}
+
+}
+
+setup_WM_LBUTTONDOWN(wParam, lParam, msg, hwnd) {
+	global
+	if (hwnd != ahko_setup.Hwnd) {
+		return
+	}
+	mx := lParam & 0xFFFF
+	my := (lParam >> 16) & 0xFFFF
+	if (mx > 32767) {
+		mx -= 65536
+	}
+	if (my > 32767) {
+		my -= 65536
+	}
+	if (my < setup_headerH && mx > 0 && mx < setup_winW - 48) {
+		PostMessage(0xA1, 2, 0, , "ahk_id " ahko_setup.Hwnd)
+	}
+}


### PR DESCRIPTION
## Summary
- Section title font `s14`→`s16` with increased label height for better readability on dark panel
- Hotkey result text upgraded to `s13 w700` with brighter accent color (`B4D0FB`) for prominence
- Close button shape changed from circle (`radius=16`) to square (`radius=4`)
- **Fixed broken hover effects**: replaced `OnMessage(0x0200)` (WM_MOUSEMOVE) with `SetTimer` + `GetCursorPos` polling at 30ms — child controls (Edit, Hotkey, DDL, CheckBox) intercept WM_MOUSEMOVE before the parent GUI, making the old approach non-functional
- Removed cursor shape switching on button hover to avoid pointer flickering
- Updated `AGENTS.md` to document the new setup GUI architecture