### PR TITLE
fix: compiled build and misfire detection

### DIFF
--- a/ahko.ahk
+++ b/ahko.ahk
@@ -16,6 +16,8 @@ if not RegExMatch(showat, showat_list)
 	showat := "10"
 }
 
+isUacMode := A_IsAdmin
+
 #include isFullScreen.ahk
 #include setup/ahko_setup_gui.ahk
 
@@ -144,7 +146,6 @@ isNotFullScreen(*)
 }
 
 #Include ahko_ui.ahk
-isUacMode := A_IsAdmin
 ahko_ui_init()
 
 ahko_invoke(*) {

--- a/ahko_gridview_ui.ahk
+++ b/ahko_gridview_ui.ahk
@@ -378,12 +378,8 @@ class ahko_gridview_class
 		this._stopMisfireDetection()
 		this._mouseCheckTimer := ObjBindMethod(this, "_checkMouseClick")
 		SetTimer(this._mouseCheckTimer, 50)
-		this._ih := InputHook("L")
-		this._ih.KeyOpt("{All}", "E")
-		this._ih.OnEnd := ObjBindMethod(this, "_onKeyboardInput")
-		this._ih.Start()
+		this._startKeyboardHook()
 	}
-
 	_stopMisfireDetection() {
 		if (this._mouseCheckTimer) {
 			SetTimer(this._mouseCheckTimer, 0)
@@ -395,7 +391,13 @@ class ahko_gridview_class
 			this._ih := ""
 		}
 	}
-
+	_startKeyboardHook() {
+		this._ih := InputHook("L")
+		this._ih.KeyOpt("{All}", "E")
+		this._ih.KeyOpt("{LCtrl}{RCtrl}{LAlt}{RAlt}{LShift}{RShift}{LWin}{RWin}", "-E")
+		this._ih.OnEnd := ObjBindMethod(this, "_onKeyboardInput")
+		this._ih.Start()
+	}
 	_checkMouseClick() {
 		if (!this._isAnyVisible()) {
 			this._stopMisfireDetection()
@@ -411,17 +413,18 @@ class ahko_gridview_class
 			MouseGetPos(, , &winId)
 			if (!this._isAhkoHwnd(winId)) {
 				this._hideAll()
+				return
 			}
 		}
 		if (DllCall("GetAsyncKeyState", "int", 0x02) & 1) {
 			MouseGetPos(, , &winId)
 			if (!this._isAhkoHwnd(winId)) {
 				this._hideAll()
+				return
 			}
 		}
 	}
-
-	_onKeyboardInput(ih, vk := 0, sc := 0) {
+	_onKeyboardInput(ih, EndReason := "") {
 		if (!this._isAnyVisible()) {
 			this._stopMisfireDetection()
 			return

--- a/app.ahk
+++ b/app.ahk
@@ -1,4 +1,4 @@
-﻿#Requires AutoHotkey v2.0
+#Requires AutoHotkey v2.0
 SetWorkingDir(A_ScriptDir)
 #Warn Unreachable, Off
 #SingleInstance force
@@ -11,8 +11,7 @@ if A_Args.Length > 0
 {
 	for n, param in A_Args
 	{
-		RegExMatch(param, "--out=(\w+)", &outName)
-		if (outName[1] == "version") {
+		if RegExMatch(param, "--out=(\w+)", &outName) && outName[1] == "version" {
 			f := FileOpen(versionFilename, "w", "UTF-8-RAW")
 			f.Write(version)
 			f.Close()

--- a/distribution.ahk
+++ b/distribution.ahk
@@ -62,6 +62,19 @@ catch as e
 	ExitApp
 }
 
+SplitPath(binaryFilename, , , , &nameNoExt)
+bundleDllName := nameNoExt "_bundled.dll"
+
+try
+{
+	RunWait("./ahk-compile-toolset/AutoHotkey64.exe gen_setup_dll.ahk")
+}
+catch as e
+{
+	MsgBox("setup DLL gen`nERROR CODE=" . e.Message)
+	ExitApp
+}
+
 try
 {
 	RunWait("./ahk-compile-toolset/AutoHotkey64.exe .\" . ahkFilename . " --out=version")
@@ -74,7 +87,7 @@ catch as e
 
 try
 {
-	RunWait("powershell -command `"Compress-Archive -Path .\" binaryFilename " -DestinationPath " downloadFilename '"', , "Hide")
+	RunWait("powershell -command `"Compress-Archive -Path .\" binaryFilename ",.\" bundleDllName " -DestinationPath " downloadFilename '"', , "Hide")
 }
 catch as e
 {
@@ -82,7 +95,8 @@ catch as e
 	ExitApp
 }
 FileDelete(binaryFilename)
+if FileExist(bundleDllName)
+	FileDelete(bundleDllName)
 FileDelete("updater.exe")
 FileMove(downloadFilename, "dist\" downloadFilename, 1)
 FileMove(versionFilename, "dist\" versionFilename, 1)
-MsgBox("Build Finished")

--- a/gen_setup_dll.ahk
+++ b/gen_setup_dll.ahk
@@ -1,0 +1,45 @@
+#Requires AutoHotkey v2.0
+SetWorkingDir(A_ScriptDir)
+#SingleInstance Force
+
+#include lib/ahk-xaml/XAML_GUI.ahk
+#include lib/ahk-xaml/AXML.ahk
+#include lib/ahk-xaml/XAML_Components.ahk
+
+global SetupAppState := AXML_State({
+	Path: "",
+	Hotkey: "",
+	HotkeyWin: "False",
+	HotkeyText: "",
+	ShowAtIndex: 0,
+	Fullscreen: "False",
+	AutoStart: "False"
+})
+
+options := Map(
+	"Sidebar", false,
+	"BurgerMenu", false,
+	"AppIcon", false,
+	"MinMaxButtons", false,
+	"Resize", false,
+	"Width", 420,
+	"Height", 530,
+	"TitleBarHeight", 40,
+	"CloseAction", "ExitApp"
+)
+
+app := XAML_GUI("ahko Setup", options)
+app.tabs.Visibility("Collapsed")
+
+result := AXML.ParseFile("setup\setup.axml", app.main, SetupAppState)
+cmb := app.X.Find("CmbShowAt")
+items := ["Primary monitor", "Follow mouse", "Follow active window", "Monitor #1", "Monitor #2"]
+for item in items {
+	cmb.Add("ComboBoxItem").Content(item)
+}
+
+ui := app.Compile()
+AXML.BindAll(ui, result, SetupAppState)
+
+app.ExportBundle("ahko_bundled.dll")
+ExitApp

--- a/lib/ahk-xaml/AXML.ahk
+++ b/lib/ahk-xaml/AXML.ahk
@@ -1,5 +1,5 @@
 #Requires AutoHotkey v2.0
-#Include "XAML_Generator.ahk"
+#Include XAML_Generator.ahk
 
 global AXML_METADATA
 

--- a/lib/ahk-xaml/XAML_Adv_Components.ahk
+++ b/lib/ahk-xaml/XAML_Adv_Components.ahk
@@ -1,8 +1,8 @@
 #Requires AutoHotkey v2.0
-#Include "XAML_Host.ahk"
-#Include "XAML_Dialog.ahk"
-#Include "XAML_Generator.ahk"
-#Include "XAML_Components.ahk"
+#Include XAML_Host.ahk
+#Include XAML_Dialog.ahk
+#Include XAML_Generator.ahk
+#Include XAML_Components.ahk
 
 ; ==============================================================================
 ; COMMAND BAR

--- a/lib/ahk-xaml/XAML_Components.ahk
+++ b/lib/ahk-xaml/XAML_Components.ahk
@@ -1,7 +1,7 @@
 #Requires AutoHotkey v2.0
-#Include "XAML_Host.ahk"
-#Include "XAML_Generator.ahk"
-#Include "XAML_Dialog.ahk"
+#Include XAML_Host.ahk
+#Include XAML_Generator.ahk
+#Include XAML_Dialog.ahk
 ; ==============================================================================
 ; SIMPLE COMPONENTS (Prototype Extensions)
 ; ==============================================================================

--- a/lib/ahk-xaml/XAML_DevTools.ahk
+++ b/lib/ahk-xaml/XAML_DevTools.ahk
@@ -1,7 +1,7 @@
 #Requires AutoHotkey v2.0
-#Include "XAML_GUI.ahk"
-#Include "XAML_Config.ahk"
-#Include "XAML_Components.ahk"
+#Include XAML_GUI.ahk
+#Include XAML_Config.ahk
+#Include XAML_Components.ahk
 
 global XAML_DevTools_Instance := ""
 

--- a/lib/ahk-xaml/XAML_Dialog.ahk
+++ b/lib/ahk-xaml/XAML_Dialog.ahk
@@ -1,6 +1,6 @@
 #Requires AutoHotkey v2.0
-#Include "XAML_Host.ahk"
-#Include "XAML_Generator.ahk"
+#Include XAML_Host.ahk
+#Include XAML_Generator.ahk
 
 class XDialog {
     static Preload() {

--- a/lib/ahk-xaml/XAML_GUI.ahk
+++ b/lib/ahk-xaml/XAML_GUI.ahk
@@ -1,8 +1,8 @@
 #Requires AutoHotkey v2.0
-#Include "XAML_Host.ahk"
-#Include "XAML_Config.ahk"
-#Include "XAML_Generator.ahk"
-#Include "*i XAML_DevTools.ahk"
+#Include XAML_Host.ahk
+#Include XAML_Config.ahk
+#Include XAML_Generator.ahk
+#Include *i XAML_DevTools.ahk
 
 class XAML_GUI {
     __New(title := "Fluid UI", options := {}) {

--- a/setup/ahko_setup_gui.ahk
+++ b/setup/ahko_setup_gui.ahk
@@ -1,8 +1,8 @@
 #Requires AutoHotkey v2.0
 #Warn Unreachable, Off
-#Include "../lib/ahk-xaml/XAML_GUI.ahk"
-#Include "../lib/ahk-xaml/AXML.ahk"
-#Include "../lib/ahk-xaml/XAML_Components.ahk"
+#Include ../lib/ahk-xaml/XAML_GUI.ahk
+#Include ../lib/ahk-xaml/AXML.ahk
+#Include ../lib/ahk-xaml/XAML_Components.ahk
 
 global SetupAppState := ""
 global setupApp := ""
@@ -48,19 +48,30 @@ setup_init() {
 	setupApp := XAML_GUI("ahko Setup", options)
 	setupApp.tabs.Visibility("Collapsed")
 
-	result := AXML.ParseFile(A_ScriptDir "\setup\setup.axml", setupApp.main, SetupAppState)
+	if (A_IsCompiled) {
+		axmlTemp := A_Temp "\ahko_setup.axml"
+		FileInstall("setup\setup.axml", axmlTemp, 1)
+		axmlPath := axmlTemp
+	} else {
+		axmlPath := A_ScriptDir "\setup\setup.axml"
+	}
+	content := FileRead(axmlPath, "UTF-8")
+	result := AXML.ParseString(content, setupApp.main, SetupAppState, "setup.axml")
 	cmb := setupApp.X.Find("CmbShowAt")
 	for item in setup_build_showAtDDL() {
 		cmb.Add("ComboBoxItem").Content(item)
 	}
 
-	setupUi := setupApp.Compile()
+	if (A_IsCompiled) {
+		setupUi := setupApp.Load("ahko_bundled.dll")
+	} else {
+		setupUi := setupApp.Compile()
+	}
 	AXML.BindAll(setupUi, result, SetupAppState)
 
 	txtHotkey := setupApp.X.Find("TxtHotkey")
 	txtHotkey._Props["Name"] := txtHotkey._Props["x:Name"]
 	setupApp.RegisterHotKeyChange(txtHotkey, setup_hotkey_changed)
-	setupUi.OnEvent("BtnClose", "Click", ahko_setup_cancel)
 	for ctrlName in ["TxtPath", "TxtHotkey", "ChkHotkeyWin", "CmbShowAt", "ChkFullscreen", "ChkAutoStart"] {
 		setupUi.Track(ctrlName)
 	}
@@ -236,7 +247,7 @@ ahko_setup_show(*) {
 	if (IsSet(ahko_gridview) && !ahko_gridview.grid_gui.isHide) {
 		ahko_gridview._hideAll()
 	}
-	Hotkey hotkeys, "Off"
+	try Hotkey hotkeys, "Off"
 	setup_init()
 	setup_sync_state_from_config()
 	setup_push_state_to_ui()


### PR DESCRIPTION
- Fix ahk2exe #Include path quoting (remove quotes for compiler compat)
- Fix compiled mode setup: ParseString + FileInstall + ahko_bundled.dll
- Add gen_setup_dll.ahk for DLL bundling in build pipeline
- Fix misfire detection: use KeyOpt('-E') to exclude modifier keys as end keys (AHK v2 KeyWaitCombo pattern)
- Fix isUacMode initialization order
- Fix RegExMatch null check in app.ahk --out handler
- Fix Hotkey hotkeys 'Off' crash when hotkey not registered