### PR TITLE
fix: CI build hangs on GUI dialogs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Build
         run: ./ahk-compile-toolset/AutoHotkey64.exe ./distribution.ahk
+        env:
+          CI: "true"
 
       - name: Create Release
         uses: softprops/action-gh-release@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ app.ahk (entry point)
 | `tray.ahk` | System tray context menu: version, Setup, GitHub, Donate, Reload, Exit |
 | `update.ahk` | Auto-update via GitHub releases API with mirror support |
 | `updater.c` / `updater.h` | C program compiled via TCC; extracts downloaded zip and restarts app |
-| `distribution.ahk` | Build script: compiles updater.c, compiles AHK to exe, creates zip in `dist/` |
+| `distribution.ahk` | Build script: compiles updater.c, compiles AHK to exe, creates zip in `dist/`. CI-aware: uses `Fail()` function that outputs to stderr in CI mode (`CI=true` env var), shows `MsgBox` in GUI mode. Checks `RunWait` exit codes and validates file existence before `FileMove` |
 | `set_auto_run.ahk` | Adds/removes app from Windows startup via Task Scheduler (`schtasks`) with admin privileges and no UAC prompt |
 
 ### Key Design Patterns
@@ -120,6 +120,7 @@ app.ahk (entry point)
 7. **ahk-xaml setup GUI** - Setup uses vendored WPF framework with AXML layout; launcher grid remains GDIp
 8. **UAC mode fallback** - When running elevated (`A_IsAdmin`), system tray is invisible (Session 0). Grid title bar gets a "More" button to access tray menu as a popup. Empty grid in UAC mode auto-opens setup GUI instead
 9. **Git submodule for toolchain** - `ahk-compile-toolset` bundles compiler and runtime
+10. **CI mode** - Build scripts detect `CI=true` environment variable to suppress GUI dialogs and use stderr for error output, preventing CI hangs
 
 ---
 
@@ -159,7 +160,7 @@ Pushing a tag matching `v*` (e.g., `v1.0.3`) triggers the GitHub Actions workflo
 
 1. Checks out the repo with submodules (for `ahk-compile-toolset`) with full history (`fetch-depth: 0`)
 2. **Auto-injects version and update_log** into `meta.ahk` via PowerShell: extracts version from tag name (e.g., `v1.0.3` → `1.0.3`) and generates `update_log` from `git log` between previous and current tags
-3. Builds via `./ahk-compile-toolset/AutoHotkey64.exe ./distribution.ahk`
+3. Builds via `./ahk-compile-toolset/AutoHotkey64.exe ./distribution.ahk` with `CI=true` environment variable
 4. Creates a GitHub Release with `dist/ahko.zip` and `dist/version.txt`
 5. Auto-generates release notes from commits between tags
 
@@ -172,7 +173,7 @@ Pushing a tag matching `v*` (e.g., `v1.0.3`) triggers the GitHub Actions workflo
 - **Classes:** Use AHK v2 class syntax with `class` keyword
 - **Config:** Runtime config via `setting.ini` (INI format)
 - **Metadata:** Version and app info centralized in `meta.ahk`
-- **Third-party code:** `Gdip_All.ahk` and `lib/ahk-xaml/` are vendored libraries; do not modify unless absolutely necessary
+- **Third-party code:** `Gdip_All.ahk` and `lib/ahk-xaml/` are vendored libraries; do not modify unless absolutely necessary. `XAML_Host.ahk` was modified to support CI mode (suppress GUI dialogs when `CI=true` env var is set)
 - **Git submodule:** `ahk-compile-toolset` is a submodule - do not commit changes to its contents directly
 
 ---

--- a/distribution.ahk
+++ b/distribution.ahk
@@ -3,6 +3,17 @@ SetWorkingDir(A_ScriptDir)
 
 #include meta.ahk
 
+isCI := (EnvGet("CI") = "true")
+
+Fail(msg) {
+	global isCI
+	if isCI
+		FileAppend("ERROR: " msg "`n", "*")
+	else
+		MsgBox(msg)
+	ExitApp(1)
+}
+
 try
 {
 	props := FileOpen("compile_prop.ahk", "w")
@@ -16,8 +27,7 @@ try
 }
 catch as e
 {
-	MsgBox("Writting compile props`nERROR CODE=" . e.Message)
-	ExitApp
+	Fail("Writting compile props`nERROR CODE=" . e.Message)
 }
 
 if FileExist(binaryFilename)
@@ -38,28 +48,31 @@ if InStr(FileExist("dist"), "D")
 	}
 	catch as e
 	{
-		MsgBox("removing dist`nERROR CODE=" . e.Message)
-		ExitApp
+		Fail("removing dist`nERROR CODE=" . e.Message)
 	}
 }
 
 DirCreate("dist")
 
 try {
-	RunWait("./ahk-compile-toolset/tcc/tcc.exe ./updater.c -luser32")
+	pid := 0
+	exitCode := RunWait("./ahk-compile-toolset/tcc/tcc.exe ./updater.c -luser32", , , &pid)
+	if (exitCode != 0)
+		Fail("updater compile`nEXIT CODE=" . exitCode)
 } catch as e {
-	MsgBox("updater compile`nERROR CODE=" . e.Message)
-	ExitApp
+	Fail("updater compile`nERROR CODE=" . e.Message)
 }
 
 try
 {
-	RunWait("./ahk-compile-toolset/ahk2exe.exe /in " ahkFilename " /out " binaryFilename " /base `"" A_AhkPath "`" /compress 1")
+	pid := 0
+	exitCode := RunWait("./ahk-compile-toolset/ahk2exe.exe /in " ahkFilename " /out " binaryFilename " /base `"" A_AhkPath "`" /compress 1", , , &pid)
+	if (exitCode != 0)
+		Fail(ahkFilename . "`nEXIT CODE=" . exitCode)
 }
 catch as e
 {
-	MsgBox(ahkFilename . "`nERROR CODE=" . e.Message)
-	ExitApp
+	Fail(ahkFilename . "`nERROR CODE=" . e.Message)
 }
 
 SplitPath(binaryFilename, , , , &nameNoExt)
@@ -67,36 +80,46 @@ bundleDllName := nameNoExt "_bundled.dll"
 
 try
 {
-	RunWait("./ahk-compile-toolset/AutoHotkey64.exe gen_setup_dll.ahk")
+	pid := 0
+	exitCode := RunWait("./ahk-compile-toolset/AutoHotkey64.exe gen_setup_dll.ahk", , , &pid)
+	if (exitCode != 0)
+		Fail("setup DLL gen`nEXIT CODE=" . exitCode)
 }
 catch as e
 {
-	MsgBox("setup DLL gen`nERROR CODE=" . e.Message)
-	ExitApp
+	Fail("setup DLL gen`nERROR CODE=" . e.Message)
 }
 
 try
 {
-	RunWait("./ahk-compile-toolset/AutoHotkey64.exe .\" . ahkFilename . " --out=version")
+	pid := 0
+	exitCode := RunWait("./ahk-compile-toolset/AutoHotkey64.exe .\" . ahkFilename . " --out=version", , , &pid)
+	if (exitCode != 0)
+		Fail("get version`nEXIT CODE=" . exitCode)
 }
 catch as e
 {
-	MsgBox("get version`nERROR CODE=" . e.Message)
-	ExitApp
+	Fail("get version`nERROR CODE=" . e.Message)
 }
 
 try
 {
-	RunWait("powershell -command `"Compress-Archive -Path .\" binaryFilename ",.\" bundleDllName " -DestinationPath " downloadFilename '"', , "Hide")
+	pid := 0
+	exitCode := RunWait("powershell -command `"Compress-Archive -Path .\" binaryFilename ",.\" bundleDllName " -DestinationPath " downloadFilename '"', , "Hide", &pid)
+	if (exitCode != 0)
+		Fail("compress`nEXIT CODE=" . exitCode)
 }
 catch as e
 {
-	MsgBox("compress`nERROR CODE=" . e.Message)
-	ExitApp
+	Fail("compress`nERROR CODE=" . e.Message)
 }
 FileDelete(binaryFilename)
 if FileExist(bundleDllName)
 	FileDelete(bundleDllName)
 FileDelete("updater.exe")
+if !FileExist(downloadFilename)
+	Fail(downloadFilename . " not found after compression")
 FileMove(downloadFilename, "dist\" downloadFilename, 1)
+if !FileExist(versionFilename)
+	Fail(versionFilename . " not found")
 FileMove(versionFilename, "dist\" versionFilename, 1)

--- a/lib/ahk-xaml/XAML_Host.ahk
+++ b/lib/ahk-xaml/XAML_Host.ahk
@@ -720,8 +720,12 @@ class XAMLHost {
 
     static CompileEngine(libDir, sharedExe, extraResources := [], embedDeps := false) {
         global XAML_ENABLE_WEBVIEW, XAML_ENABLE_AVALONEDIT, XAML_ENABLE_DOCUMENT, XAML_ENABLE_SHADERS
+        isCI := (EnvGet("CI") = "true")
         if (A_IsCompiled) {
-            MsgBox("AHK-XAML: Dynamic compilation is not available when the script is compiled. Please compile the engine separately.")
+            if isCI
+                FileAppend("ERROR: AHK-XAML: Dynamic compilation is not available when the script is compiled.`n", "*")
+            else
+                MsgBox("AHK-XAML: Dynamic compilation is not available when the script is compiled. Please compile the engine separately.")
             return
         }
 
@@ -729,7 +733,10 @@ class XAMLHost {
         errLog := A_Temp "\AhkWpf\AhkWpfError.log"
         sourceCs := libDir "\dep\XAML_AHK_Bridge.cs"
         if !FileExist(sourceCs) {
-            MsgBox("XAML_AHK_Bridge.cs not found in lib\dep directory!`nCannot compile shared engine.", "AHK-XAML", "Iconx")
+            if isCI
+                FileAppend("ERROR: XAML_AHK_Bridge.cs not found in lib\dep directory! Cannot compile shared engine.`n", "*")
+            else
+                MsgBox("XAML_AHK_Bridge.cs not found in lib\dep directory!`nCannot compile shared engine.", "AHK-XAML", "Iconx")
             return false
         }
 
@@ -838,7 +845,10 @@ class XAMLHost {
         try FileDelete(sharedExe)
         if FileExist(sharedExe) {
             SplitPath(sharedExe, &sharedName)
-            MsgBox("Error: The target DLL '" sharedName "' is locked by a running process.`n`nPlease close all running instances of your application and try compiling again.", "Build Error", "Iconx")
+            if isCI
+                FileAppend("ERROR: The target DLL '" sharedName "' is locked by a running process.`n", "*")
+            else
+                MsgBox("Error: The target DLL '" sharedName "' is locked by a running process.`n`nPlease close all running instances of your application and try compiling again.", "Build Error", "Iconx")
             return false
         }
 
@@ -885,7 +895,11 @@ class XAMLHost {
                 }
             }
 
-            XAMLHost.ShowErrorDialog("Engine Compile Error", "Failed to compile background engine.", snippet, errOut, false, reason)
+            if isCI {
+                FileAppend("ERROR: Engine Compile Error - Failed to compile background engine.`n" (reason ? "Reason: " reason "`n" : "") errOut "`n", "*")
+            } else {
+                XAMLHost.ShowErrorDialog("Engine Compile Error", "Failed to compile background engine.", snippet, errOut, false, reason)
+            }
             return false
         }
         try FileDelete(errLog)


### PR DESCRIPTION
## Summary
- Fix CI build hanging by detecting CI=true environment variable
- In CI mode, error output goes to stderr instead of showing GUI dialogs
- Check RunWait exit codes correctly (return value, not PID parameter)
- Validate file existence before FileMove operations

## Changes
- distribution.ahk: Add Fail() function with CI/GUI mode branching, exit code checks, file validation
- lib/ahk-xaml/XAML_Host.ahk: Suppress GUI dialogs in CompileEngine() when CI=true
- .github/workflows/release.yml: Set CI=true env for Build step
- AGENTS.md: Document CI mode changes

## Test Plan
- [x] Local CI mode test produces dist/ahko.zip and dist/version.txt
- [x] Local GUI mode test works normally
- [ ] Push tag to verify full CI release workflow