### PR TITLE
Apply xianii theme and redesign launcher/setup windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,23 @@
 # AGENTS.md — rusto
 
 > Cross-platform quick launcher. Tauri v2 + Svelte 5 + Tailwind v4.
+> Git repo folder: `ahko`. Product / crate / config dir name: `rusto`.
+
+## Agent Instructions (Read First)
+
+**Every agent working in this repo MUST:**
+
+1. **Read this file** before making substantive changes (architecture, IPC, deps, behavior, workflow).
+2. **Treat this document as the source of truth** for project structure, conventions, and commands.
+3. **Update this file in the same change** whenever a substantive edit would make any section stale. Do not leave AGENTS.md out of sync with the codebase.
+4. **Before finishing**, scan the diff against the triggers in [Critical Self-Sync Rule](#critical-self-sync-rule) and update affected sections.
+
+If unsure whether a change is substantive, update AGENTS.md anyway — stale docs cost more than a one-line fix.
 
 ## Project DNA
 
 - **Purpose**: 4×4 keyboard-driven grid launcher scanning a user-configured watch folder. Supports subfolders, custom openers, AppImage spawn on Linux.
-- **Backend**: Rust single-file (`src-tauri/src/lib.rs`, ~405 lines). All types, config, scanning, launch logic, window management, and tray in one module.
+- **Backend**: Rust single-file (`src-tauri/src/lib.rs`, ~436 lines). All types, config, scanning, launch logic, window management, and tray in one module.
 - **Frontend**: SvelteKit SPA (SSR disabled, `adapter-static`). Two routes: main launcher (`+page.svelte`) and setup window (`setup/+page.svelte`).
 - **IPC**: Tauri `invoke()` for commands (`load_config`, `save_config`, `scan_launcher`, `launch_item`, `hide_window`, `open_setup_window`). Tauri events (`config-changed`, `reload-request`, `show-request`) for push notifications Rust → frontend.
 - **Config**: JSON at `{OS_config_dir}/rusto/config.json`. Types mirror between Rust structs and TypeScript (camelCase serde).
@@ -15,7 +27,10 @@
 ```
 src/
 ├── routes/+page.svelte          # Main launcher UI (4×4 grid, keyboard, stagger layout)
+├── routes/+layout.svelte        # Root layout shell
+├── routes/+layout.ts            # SSR disabled (SPA mode for Tauri)
 ├── routes/setup/+page.svelte    # Config window (watch folder, hotkeys, openers)
+├── routes/setup/+page.ts        # Setup route config
 ├── lib/default-openers.ts       # Default CustomOpener presets
 ├── app.css                      # Tailwind v4 import + global resets
 └── app.html                     # HTML shell
@@ -32,7 +47,7 @@ src-tauri/
 
 - **Single-file backend**: No Rust module splitting. Keep all logic in `lib.rs`.
 - **Error handling**: `Result<T, String>` with `.map_err(|e| e.to_string())`. No custom error types.
-- **Window model**: Frameless transparent webview sized to cursor monitor's `work_area` (Kando-style). Tiles are opaque DOM elements.
+- **Window model**: Main launcher is a frameless transparent webview sized to the cursor monitor's `work_area` (Kando-style). Setup opens as a separate frameless transparent window with in-app title bar (drag + close). Tiles are opaque DOM elements.
 - **Svelte 5 runes only**: Use `$state`, `$derived`, `$derived.by`. No legacy reactive `$:` syntax.
 - **Naming**: Rust `snake_case`, TypeScript `camelCase`, CSS/Tailwind `kebab-case`.
 
@@ -67,11 +82,27 @@ cargo check            # Rust type check (run after Rust changes, in src-tauri/)
 
 ## Critical Self-Sync Rule
 
-**When any agent makes substantive changes to the project's architecture, core logic, dependencies, directory structure, commands, or development workflow — it MUST evaluate and update the corresponding sections of this AGENTS.md in the same change.** The document must always reflect the project's true current state. Specific triggers:
+**When any agent makes substantive changes to the project's architecture, core logic, dependencies, directory structure, commands, or development workflow — it MUST evaluate and update the corresponding sections of this AGENTS.md in the same change.** The document must always reflect the project's true current state.
 
-- Adding/removing/renaming source files → update `Architecture`
-- Changing Tauri commands or events → update `Project DNA` IPC section
-- Adding/removing dependencies → update `Dependencies`
-- Changing build or dev scripts → update `Commands`
-- Modifying user-visible behavior → update relevant rule sections
-- Changing error handling patterns or coding conventions → update `Coding Rules`
+### Triggers (update when any apply)
+
+| Change | Section(s) to update |
+|--------|----------------------|
+| Add/remove/rename source files | `Architecture` |
+| New/removed Tauri commands or events | `Project DNA` (IPC) |
+| Add/remove deps (npm or Cargo) | `Dependencies` |
+| Build/dev script changes | `Commands` |
+| User-visible behavior changes | `Coding Rules`, `Project DNA` |
+| Error-handling or naming convention changes | `Coding Rules`, `Key Design Decisions` |
+| Backend grows/shrinks significantly | `Project DNA` (line count) |
+| Product/config identifier rename | `Project DNA`, header, repo note |
+
+### Sync checklist (run before marking work done)
+
+- [ ] Does `Architecture` tree match actual files?
+- [ ] Are all Tauri commands/events listed correctly?
+- [ ] Do `Commands` still match `package.json` / workflow?
+- [ ] Are dependencies accurate vs `Cargo.toml` and `package.json`?
+- [ ] Do coding rules still match how the code behaves?
+
+**Never** defer AGENTS.md updates to a follow-up task. Stale AGENTS.md misleads the next agent and compounds errors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -907,7 +907,6 @@
       "integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -950,7 +949,6 @@
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -1520,7 +1518,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2117,7 +2114,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2264,7 +2260,6 @@
       "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2365,7 +2360,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2380,7 +2374,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,8 @@
     "opener:default",
     "core:window:allow-hide",
     "core:window:allow-show",
-    "core:window:allow-set-focus"
+    "core:window:allow-set-focus",
+    "core:window:allow-close",
+    "core:window:allow-start-dragging"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -238,8 +238,11 @@ fn open_or_focus_setup(app: &AppHandle) -> Result<(), String> {
     }
     WebviewWindowBuilder::new(app, "setup", setup_webview_url(app))
         .title("rusto — Setup")
-        .inner_size(440.0, 760.0)
-        .min_inner_size(360.0, 480.0)
+        .inner_size(440.0, 820.0)
+        .min_inner_size(360.0, 600.0)
+        .decorations(false)
+        .transparent(true)
+        .shadow(true)
         .resizable(true)
         .build()
         .map_err(|e| e.to_string())?;

--- a/src/app.css
+++ b/src/app.css
@@ -1,10 +1,37 @@
 @import "tailwindcss";
 
+@theme {
+  --font-sans: "Inter", "Noto Sans SC", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji";
+  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, "Cascadia Code", monospace;
+
+  --color-base-100: oklch(26% 0 0);
+  --color-base-200: oklch(20% 0 0);
+  --color-base-300: oklch(37% 0 0);
+  --color-base-content: oklch(96% 0.001 286.375);
+  --color-primary: oklch(81% 0.117 11.638);
+  --color-primary-content: oklch(26% 0 0);
+  --color-secondary: oklch(82% 0.119 306.383);
+  --color-secondary-content: oklch(26% 0 0);
+  --color-accent: oklch(80% 0.08 185);
+  --color-accent-content: oklch(26% 0 0);
+  --color-neutral: #44403c;
+  --color-neutral-content: oklch(98% 0 0);
+  --color-info: oklch(75% 0.1 250);
+  --color-success: oklch(75% 0.1 150);
+  --color-warning: oklch(82% 0.14 85);
+  --color-error: oklch(70% 0.18 25);
+
+  --radius-box: 0.5rem;
+  --radius-field: 0.5rem;
+}
+
 html,
 body {
   margin: 0;
   min-height: 100%;
   background: transparent;
+  font-family: var(--font-sans);
 }
 
 button,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,9 +21,8 @@
   /** Horizontal padding on `main` (`p-2` = 8px each side). Panel width must satisfy panelW + padX <= innerWidth. */
   const padX = 16;
 
-  /** Space above grid for breadcrumb badge (single-folder navigation only). */
-  const BREADCRUMB_H = 28;
-  const BREADCRUMB_GAP = 8;
+  /** Compact path row height (one cell wide, shorter than launcher tiles). */
+  const PATH_BAR_H = 28;
 
   /** 4×4 slot matrix (16 keys); matches backend `ITEM_KEYS` set. */
   const SLOT_ROWS: string[][] = [
@@ -42,13 +41,12 @@
   let launcherH = $state(400);
   let viewportW = $state(2000);
 
-  /** Height available for the 4 tile rows (below breadcrumb). */
-  let gridViewportH = $derived(Math.max(160, launcherH - BREADCRUMB_H - BREADCRUMB_GAP));
-
-  let gapPx = $derived(Math.max(6, Math.min(16, Math.round(gridViewportH * 0.018))));
+  let gapPx = $derived(Math.max(6, Math.min(16, Math.round(launcherH * 0.018))));
+  /** Height available for the 4 launcher tile rows (below path row). */
+  let gridViewportH = $derived(Math.max(160, launcherH - PATH_BAR_H - gapPx));
   /** Panel width = 5.5*cell + 4.5*gap; cap cell so panel + padX fits viewport. */
   let cellPx = $derived.by(() => {
-    const g = Math.max(6, Math.min(16, Math.round(gridViewportH * 0.018)));
+    const g = Math.max(6, Math.min(16, Math.round(launcherH * 0.018)));
     const fromHeight = (gridViewportH - 3 * g) / 4;
     const avail = Math.max(0, viewportW - padX);
     const fromWidth = (avail - 4.5 * g) / 5.5;
@@ -81,7 +79,7 @@
 
   const visibleItems = $derived(current ?? items);
 
-  const pathBadge = $derived(currentFolderName ? `root/${currentFolderName}` : "root");
+  const pathBadge = $derived(currentFolderName ?? "root");
 
   /** Emoji / icon row: ~60% of tile height. */
   let iconFontPx = $derived(Math.round(Math.max(14, cellPx * 0.6)));
@@ -126,6 +124,10 @@
 
   async function hide() {
     await invoke("hide_window");
+  }
+
+  async function openSetup() {
+    await invoke("open_setup_window");
   }
 
   /** Same outcome as window blur: leave submenu and hide launcher. */
@@ -214,23 +216,35 @@
 </script>
 
 <main
-  class="m-0 box-border flex h-[100dvh] min-h-[100dvh] w-full max-h-[100dvh] max-w-[100dvw] select-none items-center justify-center overflow-hidden bg-transparent p-2 text-zinc-200"
+  class="m-0 box-border flex h-[100dvh] min-h-[100dvh] w-full max-h-[100dvh] max-w-[100dvw] select-none items-center justify-center overflow-hidden bg-transparent p-2 text-base-content"
   style="box-sizing: border-box;"
   onpointerdown={onMainPointerDown}
 >
   <div
-    class="launcher-panel isolate flex max-h-full max-w-full shrink-0 flex-col box-border [contain:paint]"
-    style={`height: ${launcherH}px; width: ${panelWidthPx}px;`}
+    class="launcher-panel isolate flex max-h-full max-w-full shrink-0 flex-col justify-center box-border [contain:paint]"
+    style={`height: ${launcherH}px; width: ${panelWidthPx}px; gap: ${gapPx}px;`}
   >
     <div
-      class="mb-0 flex shrink-0 items-center overflow-hidden rounded-lg border-2 border-rose-400 bg-zinc-900 px-2.5 py-1 font-mono font-medium leading-none tracking-tight text-zinc-400"
-      style={`height: ${BREADCRUMB_H}px; min-height: ${BREADCRUMB_H}px; width: ${rowWidthPx}px; font-size: ${titleFontPx}px;`}
-      aria-live="polite"
-      title={pathBadge}
+      class="flex shrink-0 flex-row"
+      style={`margin-left: 0px; width: ${rowWidthPx}px; height: ${PATH_BAR_H}px; gap: ${gapPx}px;`}
     >
-      <span class="truncate">{pathBadge}</span>
+      <div
+        class="relative box-border flex min-w-0 shrink-0 items-center justify-center overflow-hidden rounded-lg border-2 border-base-300 bg-base-200 px-1.5 font-mono font-medium leading-none tracking-tight text-base-content/60"
+        style={`width: ${cellPx}px; height: ${PATH_BAR_H}px; font-size: ${titleFontPx}px;`}
+        aria-live="polite"
+        title={pathBadge}
+      >
+        <span class="truncate">{pathBadge}</span>
+      </div>
+      <button
+        type="button"
+        class="relative box-border flex shrink-0 items-center justify-center overflow-hidden rounded-lg border-2 border-primary bg-base-100 font-semibold leading-none text-primary outline-none transition-colors duration-150 ease-out hover:border-primary hover:bg-primary/80 hover:text-primary-content hover:ring-2 hover:ring-inset hover:ring-primary active:bg-base-100"
+        style={`width: ${cellPx}px; height: ${PATH_BAR_H}px; font-size: ${titleFontPx}px;`}
+        onclick={() => openSetup()}
+      >
+        Setup
+      </button>
     </div>
-    <div class="flex min-h-0 flex-1 shrink flex-col justify-center" style={`gap: ${gapPx}px; padding-top: ${BREADCRUMB_GAP}px`}>
     {#each SLOT_ROWS as row, ri}
       <div
         class="flex shrink-0 flex-row"
@@ -241,12 +255,12 @@
           {#if item}
             <button
               type="button"
-              class="relative box-border flex min-h-0 min-w-0 shrink-0 flex-col overflow-hidden rounded-2xl border-2 border-rose-400 bg-zinc-800 text-zinc-100 outline-none transition-colors duration-150 ease-out hover:bg-rose-400/80 hover:border-rose-300 hover:ring-2 hover:ring-inset hover:ring-rose-400 active:bg-zinc-800"
+              class="relative box-border flex min-h-0 min-w-0 shrink-0 flex-col overflow-hidden rounded-2xl border-2 border-primary bg-base-100 text-base-content outline-none transition-colors duration-150 ease-out hover:border-primary hover:bg-primary/80 hover:text-primary-content hover:ring-2 hover:ring-inset hover:ring-primary active:bg-base-100"
               style={`width: ${cellPx}px; height: ${cellPx}px;`}
               onclick={() => activate(item)}
             >
               <span
-                class="pointer-events-none absolute left-1.5 top-1.5 z-10 inline-flex h-6 min-w-6 items-center justify-center rounded border-2 border-rose-400 bg-zinc-900 px-1 font-black uppercase leading-none text-rose-200"
+                class="pointer-events-none absolute left-1.5 top-1.5 z-10 inline-flex h-6 min-w-6 items-center justify-center rounded border-2 border-primary bg-base-200 px-1 font-black uppercase leading-none text-primary"
                 style={`font-size: ${titleFontPx}px;`}
                 >{item.key}</span
               >
@@ -261,12 +275,12 @@
             </button>
           {:else}
             <div
-              class="relative box-border flex shrink-0 flex-col overflow-hidden rounded-2xl border-2 border-zinc-700 bg-zinc-900"
+              class="relative box-border flex shrink-0 flex-col overflow-hidden rounded-2xl border-2 border-base-300 bg-base-200"
               style={`width: ${cellPx}px; height: ${cellPx}px;`}
               aria-hidden="true"
             >
               <span
-                class="pointer-events-none absolute left-1.5 top-1.5 inline-flex h-6 min-w-6 items-center justify-center rounded border-2 border-zinc-600 bg-zinc-900 px-1 font-black uppercase leading-none text-zinc-500"
+                class="pointer-events-none absolute left-1.5 top-1.5 inline-flex h-6 min-w-6 items-center justify-center rounded border-2 border-base-300 bg-base-200 px-1 font-black uppercase leading-none text-base-content/40"
                 style={`font-size: ${titleFontPx}px;`}
                 >{slotKey}</span
               >
@@ -275,6 +289,5 @@
         {/each}
       </div>
     {/each}
-    </div>
   </div>
 </main>

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
+  import { getCurrentWindow } from "@tauri-apps/api/window";
   import { defaultCustomOpeners } from "$lib/default-openers";
   import { onMount } from "svelte";
 
@@ -27,7 +28,6 @@
   });
   let message = $state("");
 
-  /** In-app wake shortcut only applies where global registration exists; Linux uses OS bindings instead. */
   const isLinux =
     (import.meta as ImportMeta & { env?: { TAURI_ENV_PLATFORM?: string } }).env?.TAURI_ENV_PLATFORM ===
     "linux";
@@ -43,6 +43,15 @@
       alert(String(e));
     }
   }
+  async function closeWindow() {
+    await getCurrentWindow().close();
+  }
+  function onTitleBarPointerDown(e: PointerEvent) {
+    if (e.button !== 0) return;
+    const t = e.target;
+    if (t instanceof Element && t.closest("button")) return;
+    void getCurrentWindow().startDragging();
+  }
   function addOpener() {
     config.custom_openers = [...config.custom_openers, { extensions: [], program: "", args: ["{file}"] }];
   }
@@ -54,44 +63,61 @@
   });
 </script>
 
-<main class="min-h-screen bg-zinc-950 p-6 text-zinc-200">
-  <div
-    class="mx-auto max-w-lg rounded-3xl border-2 border-pink-400/25 bg-zinc-900/95 p-6 shadow-2xl shadow-zinc-950/50"
-  >
-    <h1 class="mb-4 text-2xl font-black text-zinc-100">Setup</h1>
-    <label class="text-sm text-zinc-500" for="watch-folder">Watch folder</label>
+<main
+  class="box-border flex h-[100dvh] flex-col overflow-hidden rounded-lg border-2 border-primary/25 bg-base-100 text-base-content"
+>
+  <div class="flex shrink-0 items-center border-b border-base-300/70">
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="flex min-w-0 flex-1 cursor-grab items-center px-5 py-3 active:cursor-grabbing"
+      onpointerdown={onTitleBarPointerDown}
+    >
+      <h1 class="text-xl font-black text-base-content">Setup</h1>
+    </div>
+    <button
+      type="button"
+      class="mr-5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-base-300 bg-base-200 text-base-content/70 transition-colors hover:border-primary/50 hover:bg-base-300 hover:text-base-content"
+      aria-label="Close"
+      onclick={() => closeWindow()}
+    >
+      ×
+    </button>
+  </div>
+
+  <div class="shrink-0 px-5 pt-4">
+    <label class="text-sm text-base-content/50" for="watch-folder">Watch folder</label>
     <input
       id="watch-folder"
-      class="mb-3 mt-1 w-full rounded-xl border border-zinc-700/80 bg-zinc-800/90 p-3 text-zinc-100 outline-none transition-colors focus:border-pink-400/50"
+      class="mb-3 mt-1 w-full rounded-lg border border-base-300/80 bg-base-100/90 p-3 text-base-content outline-none transition-colors focus:border-primary/50"
       bind:value={config.watch_folder}
       placeholder="C:\Apps or /home/me/apps"
     />
     <div class={`grid gap-2 ${isLinux ? "grid-cols-2" : "grid-cols-3"}`}>
       {#if !isLinux}
-        <label class="text-sm text-zinc-500"
+        <label class="text-sm text-base-content/50"
           >Show<input
-            class="mt-1 w-full rounded-xl border border-zinc-700/80 bg-zinc-800/90 p-2 text-zinc-100 outline-none focus:border-pink-400/50"
+            class="mt-1 w-full rounded-lg border border-base-300/80 bg-base-100/90 p-2 text-base-content outline-none focus:border-primary/50"
             bind:value={config.toggle_hotkey}
           /></label
         >
       {/if}
-      <label class="text-sm text-zinc-500"
+      <label class="text-sm text-base-content/50"
         >Back<input
-          class="mt-1 w-full rounded-xl border border-zinc-700/80 bg-zinc-800/90 p-2 text-zinc-100 outline-none focus:border-pink-400/50"
+          class="mt-1 w-full rounded-lg border border-base-300/80 bg-base-100/90 p-2 text-base-content outline-none focus:border-primary/50"
           bind:value={config.back_hotkey}
         /></label
       >
-      <label class="text-sm text-zinc-500"
+      <label class="text-sm text-base-content/50"
         >Hide<input
-          class="mt-1 w-full rounded-xl border border-zinc-700/80 bg-zinc-800/90 p-2 text-zinc-100 outline-none focus:border-pink-400/50"
+          class="mt-1 w-full rounded-lg border border-base-300/80 bg-base-100/90 p-2 text-base-content outline-none focus:border-primary/50"
           bind:value={config.hide_hotkey}
         /></label
       >
     </div>
-    <p class="my-3 rounded-xl border border-zinc-800 bg-zinc-900/80 p-3 text-xs text-zinc-500">
+    <p class="my-3 rounded-lg border border-base-300 bg-base-200/80 p-3 text-xs text-base-content/50">
       {#if isLinux}
-        Linux: wake the launcher with a <strong class="text-zinc-400">desktop shortcut</strong> or
-        <strong class="text-zinc-400">system keyboard shortcut</strong> (see README). Back / Hide apply while the launcher is
+        Linux: wake the launcher with a <strong class="text-base-content/70">desktop shortcut</strong> or
+        <strong class="text-base-content/70">system keyboard shortcut</strong> (see README). Back / Hide apply while the launcher is
         focused.
       {:else}
         Back and hide keys apply while the launcher is focused. See README for assigning a shortcut to wake or focus the app on
@@ -104,51 +130,61 @@
     <label class="mt-2 flex items-center gap-2 text-sm"
       ><input type="checkbox" bind:checked={config.autostart} /> Autostart (reserved)</label
     >
-    <div class="mt-5 flex items-center justify-between">
-      <h2 class="font-bold text-zinc-100">Custom openers</h2>
-      <button
-        class="rounded-lg border border-pink-400/40 bg-zinc-800 px-3 py-1 text-sm text-pink-200 transition-colors hover:bg-zinc-700 hover:border-pink-300/60"
-        onclick={addOpener}>Add</button
-      >
-    </div>
-    <p class="mt-2 text-xs text-zinc-500">
-      On Linux, <code class="rounded border border-zinc-700 bg-zinc-800 px-1 text-zinc-400">.AppImage</code> files launch by
-      <strong>direct spawn</strong> when no row here matches their extension. Add a custom opener only if you need a different
-      command or wrapper.
-    </p>
-    {#each config.custom_openers as opener, i}
-      <div class="mt-3 rounded-2xl border border-zinc-700/70 bg-zinc-800/60 p-3">
-        <input
-          class="mb-2 w-full rounded-lg border border-zinc-700/80 bg-zinc-900/80 p-2 text-zinc-100 outline-none focus:border-pink-400/45"
-          placeholder="extensions: py,pyw"
-          value={opener.extensions.join(",")}
-          oninput={(e) =>
-            (opener.extensions = e.currentTarget.value
-              .split(",")
-              .map((x) => x.trim())
-              .filter(Boolean))}
-        />
-        <input
-          class="mb-2 w-full rounded-lg border border-zinc-700/80 bg-zinc-900/80 p-2 text-zinc-100 outline-none focus:border-pink-400/45"
-          placeholder="program"
-          bind:value={opener.program}
-        />
-        <input
-          class="w-full rounded-lg border border-zinc-700/80 bg-zinc-900/80 p-2 text-zinc-100 outline-none focus:border-pink-400/45"
-          placeholder="args"
-          value={opener.args.join(" ")}
-          oninput={(e) => (opener.args = e.currentTarget.value.split(" ").filter(Boolean))}
-        />
+  </div>
+
+  <section class="flex min-h-0 flex-1 flex-col px-5 pt-4">
+    <div class="shrink-0">
+      <div class="flex items-center justify-between">
+        <h2 class="font-bold text-base-content">Custom openers</h2>
         <button
-          class="mt-2 text-sm text-pink-400/90 transition-colors hover:text-pink-300"
-          onclick={() => removeOpener(i)}>Remove</button
+          class="rounded-md border border-primary/40 bg-base-100 px-3 py-1 text-sm text-primary transition-colors hover:border-primary/60 hover:bg-base-300"
+          onclick={addOpener}>Add</button
         >
       </div>
-    {/each}
+      <p class="mt-2 text-xs text-base-content/50">
+        On Linux, <code class="rounded border border-base-300 bg-base-100 px-1 text-base-content/70">.AppImage</code> files launch by
+        <strong>direct spawn</strong> when no row here matches their extension. Add a custom opener only if you need a different
+        command or wrapper.
+      </p>
+    </div>
+    <div class="mt-3 min-h-[13.5rem] flex-1 overflow-y-auto pr-1">
+      {#each config.custom_openers as opener, i}
+        <div class="rounded-lg border border-base-300/70 bg-base-100/60 p-3 {i > 0 ? 'mt-3' : ''}">
+          <input
+            class="mb-2 w-full rounded-md border border-base-300/80 bg-base-200/80 p-2 text-base-content outline-none focus:border-primary/45"
+            placeholder="extensions: py,pyw"
+            value={opener.extensions.join(",")}
+            oninput={(e) =>
+              (opener.extensions = e.currentTarget.value
+                .split(",")
+                .map((x) => x.trim())
+                .filter(Boolean))}
+          />
+          <input
+            class="mb-2 w-full rounded-md border border-base-300/80 bg-base-200/80 p-2 text-base-content outline-none focus:border-primary/45"
+            placeholder="program"
+            bind:value={opener.program}
+          />
+          <input
+            class="w-full rounded-md border border-base-300/80 bg-base-200/80 p-2 text-base-content outline-none focus:border-primary/45"
+            placeholder="args"
+            value={opener.args.join(" ")}
+            oninput={(e) => (opener.args = e.currentTarget.value.split(" ").filter(Boolean))}
+          />
+          <button
+            class="mt-2 text-sm text-primary/90 transition-colors hover:text-primary"
+            onclick={() => removeOpener(i)}>Remove</button
+          >
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <div class="shrink-0 px-5 pb-4 pt-3">
     <button
-      class="mt-5 w-full rounded-xl border-2 border-pink-400/70 bg-pink-500 py-3 font-black text-zinc-950 transition-colors hover:border-pink-300 hover:bg-pink-400"
+      class="w-full rounded-lg border-2 border-primary/70 bg-primary py-3 font-black text-primary-content transition-colors hover:border-primary hover:bg-primary/90"
       onclick={save}>Save</button
     >
-    <p class="mt-2 text-center text-sm text-pink-300/90">{message}</p>
+    <p class="mt-2 text-center text-sm text-primary/90">{message}</p>
   </div>
 </main>


### PR DESCRIPTION
## Summary

- Unify launcher and setup UI with xianii design tokens (CSS variables in `app.css`)
- Redesign launcher grid and setup window layout; setup is now a frameless draggable window with openers-only scrolling
- Add aligned path/setup controls on the main launcher screen

## Test plan

- [ ] `npm run check` passes
- [ ] `cargo check` (in `src-tauri/`) passes
- [ ] Launcher grid renders with updated theme colors and typography
- [ ] Setup window opens frameless, drags from title bar, and scrolls openers section only
- [ ] Path and setup controls align correctly on the launcher


Made with [Cursor](https://cursor.com)