### PR TITLE
Add launcher screen settings and document Wayland platform limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,23 @@
 # AGENTS.md — rusto
 
 > Cross-platform quick launcher. Tauri v2 + Svelte 5 + Tailwind v4.
+> Git repo folder: `ahko`. Product / crate / config dir name: `rusto`.
+
+## Agent Instructions (Read First)
+
+**Every agent working in this repo MUST:**
+
+1. **Read this file** before making substantive changes (architecture, IPC, deps, behavior, workflow).
+2. **Treat this document as the source of truth** for project structure, conventions, and commands.
+3. **Update this file in the same change** whenever a substantive edit would make any section stale. Do not leave AGENTS.md out of sync with the codebase.
+4. **Before finishing**, scan the diff against the triggers in [Critical Self-Sync Rule](#critical-self-sync-rule) and update affected sections.
+
+If unsure whether a change is substantive, update AGENTS.md anyway — stale docs cost more than a one-line fix.
 
 ## Project DNA
 
 - **Purpose**: 4×4 keyboard-driven grid launcher scanning a user-configured watch folder. Supports subfolders, custom openers, AppImage spawn on Linux.
-- **Backend**: Rust single-file (`src-tauri/src/lib.rs`, ~405 lines). All types, config, scanning, launch logic, window management, and tray in one module.
+- **Backend**: Rust single-file (`src-tauri/src/lib.rs`, ~436 lines). All types, config, scanning, launch logic, window management, and tray in one module.
 - **Frontend**: SvelteKit SPA (SSR disabled, `adapter-static`). Two routes: main launcher (`+page.svelte`) and setup window (`setup/+page.svelte`).
 - **IPC**: Tauri `invoke()` for commands (`load_config`, `save_config`, `scan_launcher`, `launch_item`, `hide_window`, `open_setup_window`). Tauri events (`config-changed`, `reload-request`, `show-request`) for push notifications Rust → frontend.
 - **Config**: JSON at `{OS_config_dir}/rusto/config.json`. Types mirror between Rust structs and TypeScript (camelCase serde).
@@ -15,7 +27,10 @@
 ```
 src/
 ├── routes/+page.svelte          # Main launcher UI (4×4 grid, keyboard, stagger layout)
+├── routes/+layout.svelte        # Root layout shell
+├── routes/+layout.ts            # SSR disabled (SPA mode for Tauri)
 ├── routes/setup/+page.svelte    # Config window (watch folder, hotkeys, openers)
+├── routes/setup/+page.ts        # Setup route config
 ├── lib/default-openers.ts       # Default CustomOpener presets
 ├── app.css                      # Tailwind v4 import + global resets
 └── app.html                     # HTML shell
@@ -32,7 +47,7 @@ src-tauri/
 
 - **Single-file backend**: No Rust module splitting. Keep all logic in `lib.rs`.
 - **Error handling**: `Result<T, String>` with `.map_err(|e| e.to_string())`. No custom error types.
-- **Window model**: Frameless transparent webview sized to cursor monitor's `work_area` (Kando-style). Tiles are opaque DOM elements.
+- **Window model**: Main launcher is a frameless transparent webview sized to the cursor monitor's `work_area` (Kando-style). Setup opens as a separate frameless transparent window with in-app title bar (drag + close). Tiles are opaque DOM elements.
 - **Svelte 5 runes only**: Use `$state`, `$derived`, `$derived.by`. No legacy reactive `$:` syntax.
 - **Naming**: Rust `snake_case`, TypeScript `camelCase`, CSS/Tailwind `kebab-case`.
 
@@ -67,11 +82,27 @@ cargo check            # Rust type check (run after Rust changes, in src-tauri/)
 
 ## Critical Self-Sync Rule
 
-**When any agent makes substantive changes to the project's architecture, core logic, dependencies, directory structure, commands, or development workflow — it MUST evaluate and update the corresponding sections of this AGENTS.md in the same change.** The document must always reflect the project's true current state. Specific triggers:
+**When any agent makes substantive changes to the project's architecture, core logic, dependencies, directory structure, commands, or development workflow — it MUST evaluate and update the corresponding sections of this AGENTS.md in the same change.** The document must always reflect the project's true current state.
 
-- Adding/removing/renaming source files → update `Architecture`
-- Changing Tauri commands or events → update `Project DNA` IPC section
-- Adding/removing dependencies → update `Dependencies`
-- Changing build or dev scripts → update `Commands`
-- Modifying user-visible behavior → update relevant rule sections
-- Changing error handling patterns or coding conventions → update `Coding Rules`
+### Triggers (update when any apply)
+
+| Change | Section(s) to update |
+|--------|----------------------|
+| Add/remove/rename source files | `Architecture` |
+| New/removed Tauri commands or events | `Project DNA` (IPC) |
+| Add/remove deps (npm or Cargo) | `Dependencies` |
+| Build/dev script changes | `Commands` |
+| User-visible behavior changes | `Coding Rules`, `Project DNA` |
+| Error-handling or naming convention changes | `Coding Rules`, `Key Design Decisions` |
+| Backend grows/shrinks significantly | `Project DNA` (line count) |
+| Product/config identifier rename | `Project DNA`, header, repo note |
+
+### Sync checklist (run before marking work done)
+
+- [ ] Does `Architecture` tree match actual files?
+- [ ] Are all Tauri commands/events listed correctly?
+- [ ] Do `Commands` still match `package.json` / workflow?
+- [ ] Are dependencies accurate vs `Cargo.toml` and `package.json`?
+- [ ] Do coding rules still match how the code behaves?
+
+**Never** defer AGENTS.md updates to a follow-up task. Stale AGENTS.md misleads the next agent and compounds errors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,9 @@ If unsure whether a change is substantive, update AGENTS.md anyway — stale doc
 ## Project DNA
 
 - **Purpose**: 4×4 keyboard-driven grid launcher scanning a user-configured watch folder. Supports subfolders, custom openers, AppImage spawn on Linux.
-- **Backend**: Rust single-file (`src-tauri/src/lib.rs`, ~436 lines). All types, config, scanning, launch logic, window management, and tray in one module.
+- **Backend**: Rust single-file (`src-tauri/src/lib.rs`, ~613 lines). All types, config, scanning, launch logic, window management, and tray in one module.
 - **Frontend**: SvelteKit SPA (SSR disabled, `adapter-static`). Two routes: main launcher (`+page.svelte`) and setup window (`setup/+page.svelte`).
-- **IPC**: Tauri `invoke()` for commands (`load_config`, `save_config`, `scan_launcher`, `launch_item`, `hide_window`, `open_setup_window`). Tauri events (`config-changed`, `reload-request`, `show-request`) for push notifications Rust → frontend.
+- **IPC**: Tauri `invoke()` for commands (`load_config`, `save_config`, `scan_launcher`, `launch_item`, `hide_window`, `open_setup_window`, `list_monitors`, `get_platform_capabilities`). Tauri events (`config-changed`, `reload-request`, `show-request`, `monitors-changed`) for push notifications Rust → frontend.
 - **Config**: JSON at `{OS_config_dir}/rusto/config.json`. Types mirror between Rust structs and TypeScript (camelCase serde).
 
 ## Architecture
@@ -47,7 +47,7 @@ src-tauri/
 
 - **Single-file backend**: No Rust module splitting. Keep all logic in `lib.rs`.
 - **Error handling**: `Result<T, String>` with `.map_err(|e| e.to_string())`. No custom error types.
-- **Window model**: Main launcher is a frameless transparent webview sized to the cursor monitor's `work_area` (Kando-style). Setup opens as a separate frameless transparent window with in-app title bar (drag + close). Tiles are opaque DOM elements.
+- **Window model**: Main launcher is a frameless transparent webview sized to a monitor `work_area` (Kando-style). `show_at` config selects monitor: `mouse` (cursor), `focus` (active window via `active-win-pos-rs`), or `fixed` (`show_monitor_id`). **Linux Wayland**: compositor blocks `set_position`; launcher screen settings are saved but ineffective until X11 session or upstream Tauri support. Monitor list refreshes on startup and when displays change (`monitors-changed` event). Setup opens as a separate frameless transparent window with in-app title bar (drag + close). Tiles are opaque DOM elements.
 - **Svelte 5 runes only**: Use `$state`, `$derived`, `$derived.by`. No legacy reactive `$:` syntax.
 - **Naming**: Rust `snake_case`, TypeScript `camelCase`, CSS/Tailwind `kebab-case`.
 
@@ -71,13 +71,13 @@ cargo check            # Rust type check (run after Rust changes, in src-tauri/)
 - **Config sync**: Rust `AppConfig`/`CustomOpener`/`LauncherItem` structs must stay in sync with TypeScript type definitions in Svelte files.
 - **Key assignment**: Folder items use `[key]name` naming convention. Keys are from `ITEM_KEYS` array in `lib.rs`.
 - **Window behavior**: Main window hides on blur. `current` folder state resets before hide. Pointerdown outside filled tiles triggers hide.
-- **Platform awareness**: Linux skips wake hotkey in setup UI. AppImage gets direct detached spawn. Tray creation failure is non-fatal.
+- **Platform awareness**: Linux skips wake hotkey in setup UI. AppImage gets direct detached spawn. Tray creation failure is non-fatal. Linux Wayland: show launcher-screen limitation via `get_platform_capabilities`.
 
 ## Dependencies (Do Not Assume Availability)
 
 - **Always verify** a crate/package exists in `Cargo.toml` or `package.json` before importing.
 - Tauri plugins: `tauri-plugin-opener`, `tauri-plugin-single-instance` (registered in `lib.rs`).
-- Rust crates: `serde`, `serde_json`, `dirs`, `open`, `mouse_position`.
+- Rust crates: `serde`, `serde_json`, `dirs`, `open`, `mouse_position`, `active-win-pos-rs`.
 - Frontend: `@tauri-apps/api`, `@tauri-apps/plugin-opener`, Tailwind v4 via `@tailwindcss/vite`.
 
 ## Critical Self-Sync Rule

--- a/README.md
+++ b/README.md
@@ -1,6 +1,41 @@
 # rusto
 
-`rusto` is a cross-platform quick launcher for Windows and Ubuntu, rebuilt from the original AHK `ahko` reference with Rust + Tauri v2 + Svelte + Tailwind CSS.
+Cross-platform quick launcher for **Windows**, **Linux**, and **macOS**. Built with Rust + Tauri v2 + Svelte + Tailwind CSS (successor to the AHK `ahko` reference).
+
+## Platform support
+
+| Area | Windows | Linux (X11) | Linux (Wayland) | macOS |
+|------|---------|-------------|-----------------|-------|
+| Core launcher (grid, keyboard, scan folder) | Yes | Yes | Yes | Yes* |
+| Setup window | Yes | Yes | Yes | Yes* |
+| System tray | Yes | Yes† | Yes† | Yes* |
+| Launcher screen (mouse / focus / fixed) | Yes | Yes | **No** ‡ | Yes* |
+| Global wake shortcut (in-app) | Reserved | Not wired | Not wired | Reserved |
+| AppImage direct launch | — | Yes | Yes | — |
+
+\* macOS is a target of the stack (Tauri v2) but not regularly tested in this repo yet.  
+† Tray creation failure is non-fatal; use a desktop shortcut if the tray is unavailable.  
+‡ See [Linux Wayland](#linux-wayland) below.
+
+The project is **architecturally cross-platform**: one Svelte frontend and one Rust backend (`src-tauri/src/lib.rs`) compile for all three OSes via Tauri. Platform differences are handled with runtime capability checks (e.g. `get_platform_capabilities`), `TAURI_ENV_PLATFORM` in the UI, and small `cfg!(target_os = …)` branches (e.g. AppImage spawn on Linux). No separate per-OS codebases are required.
+
+What still varies by platform is mostly **desktop integration** (tray, global hotkeys, window placement), not the launcher logic itself.
+
+## Linux Wayland
+
+On **Linux Wayland** sessions (e.g. Ubuntu GNOME with `XDG_SESSION_TYPE=wayland`), the compositor does **not** allow applications to move themselves to a chosen monitor or pixel position. Tauri’s `set_position()` / `set_size()` calls succeed but are ignored ([tauri#14913](https://github.com/tauri-apps/tauri/issues/14913), [tao#566](https://github.com/tauri-apps/tao/issues/566)).
+
+**Impact on rusto:**
+
+- **Launcher screen** settings (follow mouse, follow focused window, fixed screen) are saved in config but **have no effect** on Wayland until upstream adds a supported API (e.g. fullscreen-on-monitor) or you use an **X11 session** (login screen → “Ubuntu on Xorg”).
+- The launcher may always appear on the monitor where the compositor first placed the window (often the primary display).
+- Setup shows a warning when Wayland is detected.
+
+**Workarounds:**
+
+1. Log in with an **X11** desktop session to use launcher screen settings.
+2. Use the **tray** or a **desktop shortcut** to wake the app; placement will still follow Wayland rules above.
+3. Watch [Tauri PR #14926](https://github.com/tauri-apps/tauri/pull/14926) for possible Wayland support via monitor-targeted fullscreen.
 
 ## Development
 
@@ -12,6 +47,8 @@ npm run tauri dev
 ```
 
 On Windows, ensure the Rust toolchain managed by rustup is earlier in `PATH` than any Chocolatey/system Rust installation, for example `C:\Users\xiany\.cargo\bin` before `C:\ProgramData\chocolatey\bin`.
+
+Linux build requires WebKit/GTK dev packages (see [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/)).
 
 ## Release build
 
@@ -27,19 +64,14 @@ Build the release app and platform bundles:
 npm run tauri build
 ```
 
-The release executable is generated at:
+Artifacts:
 
 ```text
-src-tauri/target/release/rusto.exe
-```
-
-Bundled installers/packages are generated under:
-
-```text
+src-tauri/target/release/rusto[.exe]
 src-tauri/target/release/bundle/
 ```
 
-To compile only the Rust release binary without generating installers:
+Rust-only release binary:
 
 ```bash
 cd src-tauri
@@ -68,3 +100,16 @@ The **Show** wake field is **hidden** in Setup because it is not wired to a glob
 
 Keep **Hide** / **Back** configured in Setup; they apply while the launcher webview has focus.
 
+### macOS
+
+Use the **tray icon** or assign a shortcut via **System Settings → Keyboard → Keyboard Shortcuts** (custom app shortcut). In-app global wake registration is not implemented yet.
+
+## Launcher screen (Setup)
+
+Choose where the fullscreen launcher appears when woken:
+
+- **Follow mouse cursor** — monitor under the pointer
+- **Follow focused window** — monitor containing the active window (via `active-win-pos-rs`; Wayland compositor support varies)
+- **Fixed screen** — always a selected display
+
+Effective on Windows, macOS, and **Linux X11**. **Not effective on Linux Wayland** (see above).

--- a/package-lock.json
+++ b/package-lock.json
@@ -907,7 +907,6 @@
       "integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -950,7 +949,6 @@
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -1520,7 +1518,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2117,7 +2114,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2264,7 +2260,6 @@
       "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2365,7 +2360,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2380,7 +2374,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3,6 +3,22 @@
 version = 4
 
 [[package]]
+name = "active-win-pos-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e2d4aadc5e08b1ae3e26c39454c18d4d3454af88edd88d3561a79e1d6062d4"
+dependencies = [
+ "appkit-nsworkspace-bindings",
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "hyprland",
+ "kdotool",
+ "objc",
+ "windows 0.48.0",
+ "xcb",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +62,16 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "appkit-nsworkspace-bindings"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062382938604cfa02c03689ab75af0e7eb79175ba0d0b2bcfad18f5190702dd7"
+dependencies = [
+ "bindgen",
+ "objc",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -98,7 +124,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -129,7 +155,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -155,10 +181,32 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -224,6 +272,29 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+ "which",
+]
 
 [[package]]
 name = "bit-set"
@@ -424,6 +495,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,9 +537,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -486,6 +579,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -533,6 +635,19 @@ dependencies = [
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
  "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -666,12 +781,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -689,13 +828,35 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -709,12 +870,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -736,10 +928,12 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -890,6 +1084,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embed-resource"
@@ -1504,6 +1704,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43ccdfe15a81ab0a8af639e90254227c9a46afd9c5f5b6ec7efaa345c4b0f00"
+dependencies = [
+ "derive_builder",
+ "log",
+ "num-order",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +1763,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "html5ever"
@@ -1650,6 +1875,34 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyprland"
+version = "0.4.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fc24052f578592af91e5c60da1893ba6aea266b6ab86ffb72a644cf213fea9"
+dependencies = [
+ "async-stream",
+ "derive_more 2.1.1",
+ "either",
+ "futures-lite",
+ "hyprland-macros",
+ "pastey",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
+name = "hyprland-macros"
+version = "0.4.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31157e6ccefbad4b0cd7e549db6696691a70c11b108f26bf6bf76eef26af8c10"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1989,6 +2242,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "kdotool"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2eee83d474f719244c71d8ebbe360b5634ed76e4da6bdfae9524cf9de6b9e4c"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "dbus",
+ "handlebars",
+ "log",
+ "phf 0.13.1",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,6 +2280,18 @@ dependencies = [
  "indexmap 2.14.0",
  "selectors 0.24.0",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128fmt"
@@ -2037,7 +2319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2046,6 +2328,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2058,6 +2349,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,6 +2366,12 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2098,6 +2405,15 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "markup5ever"
@@ -2161,6 +2477,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2268,10 +2590,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-modular"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d1aedba5cebbd8d4e97e7e71409b00c11e277e754d1a6701695e23ef6775d7"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
+]
 
 [[package]]
 name = "num-traits"
@@ -2302,6 +2649,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -2516,16 +2872,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "phf"
@@ -2745,7 +3156,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.2",
  "serde",
  "time",
 ]
@@ -2786,7 +3197,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2903,6 +3314,15 @@ name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -3137,6 +3557,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -3152,6 +3578,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3159,7 +3598,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3167,6 +3606,7 @@ dependencies = [
 name = "rusto"
 version = "0.1.0"
 dependencies = [
+ "active-win-pos-rs",
  "dirs 5.0.1",
  "mouse_position",
  "open",
@@ -3282,7 +3722,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "servo_arc 0.4.3",
  "smallvec",
 ]
@@ -3417,7 +3857,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3738,7 +4178,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3810,7 +4250,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3911,7 +4351,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -3952,7 +4392,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3977,7 +4417,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4039,7 +4479,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4407,6 +4847,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uds_windows"
@@ -4784,7 +5230,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -4808,8 +5254,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -4856,6 +5314,15 @@ dependencies = [
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
+]
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5475,7 +5942,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5500,6 +5967,17 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xcb"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "quick-xml 0.30.0",
 ]
 
 [[package]]
@@ -5547,7 +6025,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,5 +29,6 @@ serde_json = "1"
 dirs = "5"
 open = "5"
 mouse_position = "0.1"
+active-win-pos-rs = "0.11"
 
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,8 @@
     "opener:default",
     "core:window:allow-hide",
     "core:window:allow-show",
-    "core:window:allow-set-focus"
+    "core:window:allow-set-focus",
+    "core:window:allow-close",
+    "core:window:allow-start-dragging"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,11 +5,14 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::{Command, Stdio},
+    sync::Mutex,
+    time::Duration,
 };
 use tauri::{
     menu::{Menu, MenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    AppHandle, Emitter, Manager, PhysicalPosition, PhysicalSize, WebviewUrl, WebviewWindowBuilder,
+    AppHandle, Emitter, Manager, Monitor, PhysicalPosition, PhysicalSize, WebviewUrl,
+    WebviewWindow, WebviewWindowBuilder,
 };
 
 const ITEM_KEYS: [&str; 16] = ["1", "2", "3", "q", "w", "e", "a", "s", "d", "4", "r", "f", "z", "x", "c", "v"];
@@ -28,6 +31,8 @@ pub struct AppConfig {
     pub back_hotkey: String,
     pub hide_hotkey: String,
     pub show_at: String,
+    #[serde(default)]
+    pub show_monitor_id: String,
     pub enable_in_fullscreen: bool,
     pub autostart: bool,
     pub custom_openers: Vec<CustomOpener>,
@@ -51,6 +56,29 @@ fn default_custom_openers() -> Vec<CustomOpener> {
     }]
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct PlatformCapabilities {
+    pub session_type: String,
+    pub desktop: String,
+    pub launcher_screen_supported: bool,
+    pub launcher_screen_note: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MonitorInfo {
+    pub id: String,
+    pub name: String,
+    pub is_primary: bool,
+    pub width: u32,
+    pub height: u32,
+    pub x: i32,
+    pub y: i32,
+}
+
+struct MonitorWatchState {
+    fingerprint: Mutex<Vec<String>>,
+}
+
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
@@ -59,6 +87,7 @@ impl Default for AppConfig {
             back_hotkey: "`".into(),
             hide_hotkey: "Esc".into(),
             show_at: "mouse".into(),
+            show_monitor_id: String::new(),
             enable_in_fullscreen: false,
             autostart: false,
             custom_openers: default_custom_openers(),
@@ -178,47 +207,195 @@ fn scan_level(dir: &Path, inner: bool) -> Vec<LauncherItem> {
     result
 }
 
-/// Resize and move `main` to the **work area** (taskbar/dock excluded) of the monitor that
-/// contains the mouse cursor, falling back to primary then first monitor — same idea as
-/// Kando’s full-screen transparent menu window.
-fn fit_main_to_cursor_work_area(app: &AppHandle) {
-    let Some(w) = app.get_webview_window("main") else {
-        return;
-    };
-    let Ok(monitors) = w.available_monitors() else {
-        return;
-    };
-    let primary = w.primary_monitor().ok().flatten();
-    let mon = match Mouse::get_mouse_position() {
-        Mouse::Position { x, y } => monitors.iter().find(|m| {
-            let p = m.position();
-            let s = m.size();
-            x >= p.x
-                && x < p.x + s.width as i32
-                && y >= p.y
-                && y < p.y + s.height as i32
-        }),
-        Mouse::Error => None,
-    }
-    .or_else(|| primary.as_ref())
-    .or_else(|| monitors.first());
+/// Resize and move `main` to the **work area** of the monitor chosen by config
+/// (`mouse` | `focus` | `fixed`), falling back to primary then first monitor.
+fn monitor_id(m: &Monitor) -> String {
+    let p = m.position();
+    let s = m.size();
+    format!("{}x{}@{},{}", s.width, s.height, p.x, p.y)
+}
 
-    if let Some(m) = mon {
-        let wa = m.work_area();
-        let _ = w.set_position(PhysicalPosition::new(wa.position.x, wa.position.y));
-        let _ = w.set_size(PhysicalSize::new(wa.size.width, wa.size.height));
+fn monitor_label(m: &Monitor) -> String {
+    if let Some(name) = m.name().filter(|n| !n.is_empty()) {
+        name.clone()
+    } else {
+        let p = m.position();
+        let s = m.size();
+        format!("{}×{} @ {},{}", s.width, s.height, p.x, p.y)
     }
 }
 
+fn monitors_same(a: &Monitor, b: &Monitor) -> bool {
+    monitor_id(a) == monitor_id(b)
+}
+
+fn monitor_at_point(monitors: &[Monitor], x: i32, y: i32) -> Option<Monitor> {
+    monitors.iter().find(|m| {
+        let p = m.position();
+        let s = m.size();
+        x >= p.x
+            && x < p.x + s.width as i32
+            && y >= p.y
+            && y < p.y + s.height as i32
+    }).cloned()
+}
+
+fn find_monitor_by_id(monitors: &[Monitor], id: &str) -> Option<Monitor> {
+    if id.is_empty() {
+        return None;
+    }
+    if let Some(m) = monitors.iter().find(|m| monitor_id(m) == id).cloned() {
+        return Some(m);
+    }
+    monitors
+        .iter()
+        .find(|m| m.name().is_some_and(|n| n == id))
+        .cloned()
+}
+
+fn desktop_cursor_point(w: &WebviewWindow) -> Option<(i32, i32)> {
+    if let Ok(pos) = w.cursor_position() {
+        return Some((pos.x.round() as i32, pos.y.round() as i32));
+    }
+    match Mouse::get_mouse_position() {
+        Mouse::Position { x, y } => Some((x, y)),
+        Mouse::Error => None,
+    }
+}
+
+fn monitor_for_point(w: &WebviewWindow, monitors: &[Monitor], x: i32, y: i32) -> Option<Monitor> {
+    w.monitor_from_point(x as f64, y as f64)
+        .ok()
+        .flatten()
+        .or_else(|| monitor_at_point(monitors, x, y))
+}
+
+fn focused_window_center() -> Option<(i32, i32)> {
+    active_win_pos_rs::get_active_window().ok().map(|w| {
+        (
+            (w.position.x + w.position.width / 2.0) as i32,
+            (w.position.y + w.position.height / 2.0) as i32,
+        )
+    })
+}
+
+fn collect_monitor_infos(w: &WebviewWindow) -> Result<Vec<MonitorInfo>, String> {
+    let monitors = w.available_monitors().map_err(|e| e.to_string())?;
+    let primary = w.primary_monitor().map_err(|e| e.to_string())?;
+    Ok(monitors
+        .into_iter()
+        .map(|m| {
+            let p = m.position();
+            let s = m.size();
+            MonitorInfo {
+                id: monitor_id(&m),
+                name: monitor_label(&m),
+                is_primary: primary.as_ref().is_some_and(|pm| monitors_same(pm, &m)),
+                width: s.width,
+                height: s.height,
+                x: p.x,
+                y: p.y,
+            }
+        })
+        .collect())
+}
+
+fn monitor_fingerprints(w: &WebviewWindow) -> Result<Vec<String>, String> {
+    Ok(w.available_monitors()
+        .map_err(|e| e.to_string())?
+        .iter()
+        .map(monitor_id)
+        .collect())
+}
+
+fn pick_target_monitor(w: &WebviewWindow, config: &AppConfig) -> Option<Monitor> {
+    let monitors = w.available_monitors().ok()?;
+    if monitors.is_empty() {
+        return None;
+    }
+    let primary = w.primary_monitor().ok().flatten();
+    let fallback = || primary.clone().or_else(|| monitors.first().cloned());
+
+    match config.show_at.as_str() {
+        "fixed" => find_monitor_by_id(&monitors, &config.show_monitor_id).or_else(fallback),
+        "focus" => focused_window_center()
+            .and_then(|(x, y)| monitor_for_point(w, &monitors, x, y))
+            .or_else(fallback),
+        _ => desktop_cursor_point(w)
+            .and_then(|(x, y)| monitor_for_point(w, &monitors, x, y))
+            .or_else(fallback),
+    }
+}
+
+fn apply_monitor_work_area(w: &WebviewWindow, mon: &Monitor) {
+    let wa = mon.work_area();
+    let _ = w.set_position(PhysicalPosition::new(wa.position.x, wa.position.y));
+    let _ = w.set_size(PhysicalSize::new(wa.size.width, wa.size.height));
+}
+
+fn fit_main_to_work_area(app: &AppHandle, config: &AppConfig) {
+    let Some(w) = app.get_webview_window("main") else {
+        return;
+    };
+    if let Some(m) = pick_target_monitor(&w, config) {
+        apply_monitor_work_area(&w, &m);
+    }
+}
+
+fn emit_monitors_if_changed(app: &AppHandle) {
+    let Some(w) = app.get_webview_window("main") else {
+        return;
+    };
+    let Ok(fps) = monitor_fingerprints(&w) else {
+        return;
+    };
+    let state = app.state::<MonitorWatchState>();
+    let mut last = state.fingerprint.lock().expect("monitor watch lock");
+    if *last == fps {
+        return;
+    }
+    *last = fps;
+    drop(last);
+    if let Ok(infos) = collect_monitor_infos(&w) {
+        let _ = app.emit("monitors-changed", infos);
+    }
+}
+
+fn publish_monitors(app: &AppHandle) {
+    let Some(w) = app.get_webview_window("main") else {
+        return;
+    };
+    if let Ok(fps) = monitor_fingerprints(&w) {
+        *app
+            .state::<MonitorWatchState>()
+            .fingerprint
+            .lock()
+            .expect("monitor watch lock") = fps;
+    }
+    if let Ok(infos) = collect_monitor_infos(&w) {
+        let _ = app.emit("monitors-changed", infos);
+    }
+}
+
+fn start_monitor_watch(app: AppHandle) {
+    std::thread::spawn(move || loop {
+        std::thread::sleep(Duration::from_secs(2));
+        let handle = app.clone();
+        let _ = handle.run_on_main_thread({
+            let handle = handle.clone();
+            move || emit_monitors_if_changed(&handle)
+        });
+    });
+}
+
 fn show_main(app: &AppHandle) {
-    fit_main_to_cursor_work_area(app);
+    let config = load_config().unwrap_or_default();
     if let Some(w) = app.get_webview_window("main") {
         let _ = w.show();
+        fit_main_to_work_area(app, &config);
         let _ = w.set_always_on_top(true);
         let _ = w.set_focus();
-        // Request user attention (flashing taskbar) as a fallback for stubborn WMs
         let _ = w.request_user_attention(Some(tauri::UserAttentionType::Critical));
-        // Notify frontend to grab focus explicitly
         let _ = app.emit_to("main", "show-request", ());
     }
 }
@@ -238,7 +415,7 @@ fn open_or_focus_setup(app: &AppHandle) -> Result<(), String> {
     }
     WebviewWindowBuilder::new(app, "setup", setup_webview_url(app))
         .title("rusto — Setup")
-        .inner_size(440.0, 820.0)
+        .inner_size(440.0, 880.0)
         .min_inner_size(360.0, 600.0)
         .decorations(false)
         .transparent(true)
@@ -247,6 +424,36 @@ fn open_or_focus_setup(app: &AppHandle) -> Result<(), String> {
         .build()
         .map_err(|e| e.to_string())?;
     Ok(())
+}
+
+#[tauri::command]
+fn get_platform_capabilities() -> PlatformCapabilities {
+    let session_type = std::env::var("XDG_SESSION_TYPE").unwrap_or_else(|_| "unknown".into());
+    let desktop = std::env::var("XDG_CURRENT_DESKTOP").unwrap_or_else(|_| "unknown".into());
+    let wayland = session_type.eq_ignore_ascii_case("wayland");
+    let launcher_screen_supported = !(cfg!(target_os = "linux") && wayland);
+    let launcher_screen_note = if launcher_screen_supported {
+        String::new()
+    } else {
+        "Linux Wayland (e.g. Ubuntu GNOME) does not allow apps to choose their screen. \
+         Launcher screen settings are saved but have no effect until you log into an X11 session \
+         or Tauri adds Wayland support."
+            .into()
+    };
+    PlatformCapabilities {
+        session_type,
+        desktop,
+        launcher_screen_supported,
+        launcher_screen_note,
+    }
+}
+
+#[tauri::command]
+fn list_monitors(app: AppHandle) -> Result<Vec<MonitorInfo>, String> {
+    let w = app
+        .get_webview_window("main")
+        .ok_or_else(|| "Main window not found".to_string())?;
+    collect_monitor_infos(&w)
 }
 
 #[tauri::command]
@@ -289,9 +496,21 @@ fn validate_custom_openers(openers: &[CustomOpener]) -> Result<(), String> {
     Ok(())
 }
 
+fn validate_show_at(config: &AppConfig) -> Result<(), String> {
+    match config.show_at.as_str() {
+        "mouse" | "focus" | "fixed" => {}
+        other => return Err(format!("Invalid launcher screen mode: {other}")),
+    }
+    if config.show_at == "fixed" && config.show_monitor_id.trim().is_empty() {
+        return Err("Select a screen when launcher position is fixed".into());
+    }
+    Ok(())
+}
+
 #[tauri::command]
 fn save_config(app: AppHandle, config: AppConfig) -> Result<(), String> {
     validate_custom_openers(&config.custom_openers)?;
+    validate_show_at(&config)?;
     let dir = config_dir()?;
     fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
     fs::write(
@@ -299,6 +518,7 @@ fn save_config(app: AppHandle, config: AppConfig) -> Result<(), String> {
         serde_json::to_string_pretty(&config).map_err(|e| e.to_string())?,
     )
     .map_err(|e| e.to_string())?;
+    fit_main_to_work_area(&app, &config);
     let _ = app.emit_to("main", "config-changed", ());
     Ok(())
 }
@@ -388,6 +608,9 @@ pub fn run() {
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             show_main(app);
         }))
+        .manage(MonitorWatchState {
+            fingerprint: Mutex::new(Vec::new()),
+        })
         .setup(|app| {
             let show = MenuItem::with_id(app, "show", "Show", true, None::<&str>)?;
             let setup = MenuItem::with_id(app, "setup", "Setup", true, None::<&str>)?;
@@ -423,7 +646,10 @@ pub fn run() {
             {
                 eprintln!("rusto: system tray unavailable ({e}). The app will still run; use the main window or bind a desktop shortcut to show it.");
             }
-            fit_main_to_cursor_work_area(&app.handle());
+            let config = load_config().unwrap_or_default();
+            fit_main_to_work_area(&app.handle(), &config);
+            publish_monitors(&app.handle());
+            start_monitor_watch(app.handle().clone());
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -432,7 +658,9 @@ pub fn run() {
             scan_launcher,
             launch_item,
             hide_window,
-            open_setup_window
+            open_setup_window,
+            list_monitors,
+            get_platform_capabilities
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -238,8 +238,11 @@ fn open_or_focus_setup(app: &AppHandle) -> Result<(), String> {
     }
     WebviewWindowBuilder::new(app, "setup", setup_webview_url(app))
         .title("rusto — Setup")
-        .inner_size(440.0, 760.0)
-        .min_inner_size(360.0, 480.0)
+        .inner_size(440.0, 820.0)
+        .min_inner_size(360.0, 600.0)
+        .decorations(false)
+        .transparent(true)
+        .shadow(true)
         .resizable(true)
         .build()
         .map_err(|e| e.to_string())?;

--- a/src/app.css
+++ b/src/app.css
@@ -39,3 +39,18 @@ input,
 select {
   font: inherit;
 }
+
+select,
+select option {
+  color-scheme: dark;
+  background-color: var(--color-base-200);
+  color: var(--color-base-content);
+}
+
+select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23a1a1aa' d='M2.5 4.5 6 8l3.5-3.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.65rem center;
+  padding-right: 2rem;
+}

--- a/src/app.css
+++ b/src/app.css
@@ -1,10 +1,37 @@
 @import "tailwindcss";
 
+@theme {
+  --font-sans: "Inter", "Noto Sans SC", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji";
+  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, "Cascadia Code", monospace;
+
+  --color-base-100: oklch(26% 0 0);
+  --color-base-200: oklch(20% 0 0);
+  --color-base-300: oklch(37% 0 0);
+  --color-base-content: oklch(96% 0.001 286.375);
+  --color-primary: oklch(81% 0.117 11.638);
+  --color-primary-content: oklch(26% 0 0);
+  --color-secondary: oklch(82% 0.119 306.383);
+  --color-secondary-content: oklch(26% 0 0);
+  --color-accent: oklch(80% 0.08 185);
+  --color-accent-content: oklch(26% 0 0);
+  --color-neutral: #44403c;
+  --color-neutral-content: oklch(98% 0 0);
+  --color-info: oklch(75% 0.1 250);
+  --color-success: oklch(75% 0.1 150);
+  --color-warning: oklch(82% 0.14 85);
+  --color-error: oklch(70% 0.18 25);
+
+  --radius-box: 0.5rem;
+  --radius-field: 0.5rem;
+}
+
 html,
 body {
   margin: 0;
   min-height: 100%;
   background: transparent;
+  font-family: var(--font-sans);
 }
 
 button,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,9 +21,8 @@
   /** Horizontal padding on `main` (`p-2` = 8px each side). Panel width must satisfy panelW + padX <= innerWidth. */
   const padX = 16;
 
-  /** Space above grid for breadcrumb badge (single-folder navigation only). */
-  const BREADCRUMB_H = 28;
-  const BREADCRUMB_GAP = 8;
+  /** Compact path row height (one cell wide, shorter than launcher tiles). */
+  const PATH_BAR_H = 28;
 
   /** 4×4 slot matrix (16 keys); matches backend `ITEM_KEYS` set. */
   const SLOT_ROWS: string[][] = [
@@ -42,13 +41,12 @@
   let launcherH = $state(400);
   let viewportW = $state(2000);
 
-  /** Height available for the 4 tile rows (below breadcrumb). */
-  let gridViewportH = $derived(Math.max(160, launcherH - BREADCRUMB_H - BREADCRUMB_GAP));
-
-  let gapPx = $derived(Math.max(6, Math.min(16, Math.round(gridViewportH * 0.018))));
+  let gapPx = $derived(Math.max(6, Math.min(16, Math.round(launcherH * 0.018))));
+  /** Height available for the 4 launcher tile rows (below path row). */
+  let gridViewportH = $derived(Math.max(160, launcherH - PATH_BAR_H - gapPx));
   /** Panel width = 5.5*cell + 4.5*gap; cap cell so panel + padX fits viewport. */
   let cellPx = $derived.by(() => {
-    const g = Math.max(6, Math.min(16, Math.round(gridViewportH * 0.018)));
+    const g = Math.max(6, Math.min(16, Math.round(launcherH * 0.018)));
     const fromHeight = (gridViewportH - 3 * g) / 4;
     const avail = Math.max(0, viewportW - padX);
     const fromWidth = (avail - 4.5 * g) / 5.5;
@@ -81,7 +79,7 @@
 
   const visibleItems = $derived(current ?? items);
 
-  const pathBadge = $derived(currentFolderName ? `root/${currentFolderName}` : "root");
+  const pathBadge = $derived(currentFolderName ?? "root");
 
   /** Emoji / icon row: ~60% of tile height. */
   let iconFontPx = $derived(Math.round(Math.max(14, cellPx * 0.6)));
@@ -126,6 +124,10 @@
 
   async function hide() {
     await invoke("hide_window");
+  }
+
+  async function openSetup() {
+    await invoke("open_setup_window");
   }
 
   /** Same outcome as window blur: leave submenu and hide launcher. */
@@ -214,23 +216,35 @@
 </script>
 
 <main
-  class="m-0 box-border flex h-[100dvh] min-h-[100dvh] w-full max-h-[100dvh] max-w-[100dvw] select-none items-center justify-center overflow-hidden bg-transparent p-2 text-zinc-200"
+  class="m-0 box-border flex h-[100dvh] min-h-[100dvh] w-full max-h-[100dvh] max-w-[100dvw] select-none items-center justify-center overflow-hidden bg-transparent p-2 text-base-content"
   style="box-sizing: border-box;"
   onpointerdown={onMainPointerDown}
 >
   <div
-    class="launcher-panel isolate flex max-h-full max-w-full shrink-0 flex-col box-border [contain:paint]"
-    style={`height: ${launcherH}px; width: ${panelWidthPx}px;`}
+    class="launcher-panel isolate flex max-h-full max-w-full shrink-0 flex-col justify-center box-border [contain:paint]"
+    style={`height: ${launcherH}px; width: ${panelWidthPx}px; gap: ${gapPx}px;`}
   >
     <div
-      class="mb-0 flex shrink-0 items-center overflow-hidden rounded-lg border-2 border-rose-400 bg-zinc-900 px-2.5 py-1 font-mono font-medium leading-none tracking-tight text-zinc-400"
-      style={`height: ${BREADCRUMB_H}px; min-height: ${BREADCRUMB_H}px; width: ${rowWidthPx}px; font-size: ${titleFontPx}px;`}
-      aria-live="polite"
-      title={pathBadge}
+      class="flex shrink-0 flex-row"
+      style={`margin-left: 0px; width: ${rowWidthPx}px; height: ${PATH_BAR_H}px; gap: ${gapPx}px;`}
     >
-      <span class="truncate">{pathBadge}</span>
+      <div
+        class="relative box-border flex min-w-0 shrink-0 items-center justify-center overflow-hidden rounded-lg border-2 border-base-300 bg-base-200 px-1.5 font-mono font-medium leading-none tracking-tight text-base-content/60"
+        style={`width: ${cellPx}px; height: ${PATH_BAR_H}px; font-size: ${titleFontPx}px;`}
+        aria-live="polite"
+        title={pathBadge}
+      >
+        <span class="truncate">{pathBadge}</span>
+      </div>
+      <button
+        type="button"
+        class="relative box-border flex shrink-0 items-center justify-center overflow-hidden rounded-lg border-2 border-primary bg-base-100 font-semibold leading-none text-primary outline-none transition-colors duration-150 ease-out hover:border-primary hover:bg-primary/80 hover:text-primary-content hover:ring-2 hover:ring-inset hover:ring-primary active:bg-base-100"
+        style={`width: ${cellPx}px; height: ${PATH_BAR_H}px; font-size: ${titleFontPx}px;`}
+        onclick={() => openSetup()}
+      >
+        Setup
+      </button>
     </div>
-    <div class="flex min-h-0 flex-1 shrink flex-col justify-center" style={`gap: ${gapPx}px; padding-top: ${BREADCRUMB_GAP}px`}>
     {#each SLOT_ROWS as row, ri}
       <div
         class="flex shrink-0 flex-row"
@@ -241,12 +255,12 @@
           {#if item}
             <button
               type="button"
-              class="relative box-border flex min-h-0 min-w-0 shrink-0 flex-col overflow-hidden rounded-2xl border-2 border-rose-400 bg-zinc-800 text-zinc-100 outline-none transition-colors duration-150 ease-out hover:bg-rose-400/80 hover:border-rose-300 hover:ring-2 hover:ring-inset hover:ring-rose-400 active:bg-zinc-800"
+              class="relative box-border flex min-h-0 min-w-0 shrink-0 flex-col overflow-hidden rounded-2xl border-2 border-primary bg-base-100 text-base-content outline-none transition-colors duration-150 ease-out hover:border-primary hover:bg-primary/80 hover:text-primary-content hover:ring-2 hover:ring-inset hover:ring-primary active:bg-base-100"
               style={`width: ${cellPx}px; height: ${cellPx}px;`}
               onclick={() => activate(item)}
             >
               <span
-                class="pointer-events-none absolute left-1.5 top-1.5 z-10 inline-flex h-6 min-w-6 items-center justify-center rounded border-2 border-rose-400 bg-zinc-900 px-1 font-black uppercase leading-none text-rose-200"
+                class="pointer-events-none absolute left-1.5 top-1.5 z-10 inline-flex h-6 min-w-6 items-center justify-center rounded border-2 border-primary bg-base-200 px-1 font-black uppercase leading-none text-primary"
                 style={`font-size: ${titleFontPx}px;`}
                 >{item.key}</span
               >
@@ -261,12 +275,12 @@
             </button>
           {:else}
             <div
-              class="relative box-border flex shrink-0 flex-col overflow-hidden rounded-2xl border-2 border-zinc-700 bg-zinc-900"
+              class="relative box-border flex shrink-0 flex-col overflow-hidden rounded-2xl border-2 border-base-300 bg-base-200"
               style={`width: ${cellPx}px; height: ${cellPx}px;`}
               aria-hidden="true"
             >
               <span
-                class="pointer-events-none absolute left-1.5 top-1.5 inline-flex h-6 min-w-6 items-center justify-center rounded border-2 border-zinc-600 bg-zinc-900 px-1 font-black uppercase leading-none text-zinc-500"
+                class="pointer-events-none absolute left-1.5 top-1.5 inline-flex h-6 min-w-6 items-center justify-center rounded border-2 border-base-300 bg-base-200 px-1 font-black uppercase leading-none text-base-content/40"
                 style={`font-size: ${titleFontPx}px;`}
                 >{slotKey}</span
               >
@@ -275,6 +289,5 @@
         {/each}
       </div>
     {/each}
-    </div>
   </div>
 </main>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,6 +12,7 @@
     back_hotkey: string;
     hide_hotkey: string;
     show_at: string;
+    show_monitor_id: string;
     enable_in_fullscreen: boolean;
     autostart: boolean;
     custom_openers: CustomOpener[];
@@ -68,6 +69,7 @@
     back_hotkey: "`",
     hide_hotkey: "Esc",
     show_at: "mouse",
+    show_monitor_id: "",
     enable_in_fullscreen: false,
     autostart: false,
     custom_openers: defaultCustomOpeners(),

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
+  import { getCurrentWindow } from "@tauri-apps/api/window";
   import { defaultCustomOpeners } from "$lib/default-openers";
   import { onMount } from "svelte";
 
@@ -27,7 +28,6 @@
   });
   let message = $state("");
 
-  /** In-app wake shortcut only applies where global registration exists; Linux uses OS bindings instead. */
   const isLinux =
     (import.meta as ImportMeta & { env?: { TAURI_ENV_PLATFORM?: string } }).env?.TAURI_ENV_PLATFORM ===
     "linux";
@@ -43,6 +43,15 @@
       alert(String(e));
     }
   }
+  async function closeWindow() {
+    await getCurrentWindow().close();
+  }
+  function onTitleBarPointerDown(e: PointerEvent) {
+    if (e.button !== 0) return;
+    const t = e.target;
+    if (t instanceof Element && t.closest("button")) return;
+    void getCurrentWindow().startDragging();
+  }
   function addOpener() {
     config.custom_openers = [...config.custom_openers, { extensions: [], program: "", args: ["{file}"] }];
   }
@@ -54,44 +63,61 @@
   });
 </script>
 
-<main class="min-h-screen bg-zinc-950 p-6 text-zinc-200">
-  <div
-    class="mx-auto max-w-lg rounded-3xl border-2 border-pink-400/25 bg-zinc-900/95 p-6 shadow-2xl shadow-zinc-950/50"
-  >
-    <h1 class="mb-4 text-2xl font-black text-zinc-100">Setup</h1>
-    <label class="text-sm text-zinc-500" for="watch-folder">Watch folder</label>
+<main
+  class="box-border flex h-[100dvh] flex-col overflow-hidden rounded-lg border-2 border-primary/25 bg-base-100 text-base-content"
+>
+  <div class="flex shrink-0 items-center border-b border-base-300/70">
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="flex min-w-0 flex-1 cursor-grab items-center px-5 py-3 active:cursor-grabbing"
+      onpointerdown={onTitleBarPointerDown}
+    >
+      <h1 class="text-xl font-black text-base-content">Setup</h1>
+    </div>
+    <button
+      type="button"
+      class="mr-5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-base-300 bg-base-200 text-base-content/70 transition-colors hover:border-primary/50 hover:bg-base-300 hover:text-base-content"
+      aria-label="Close"
+      onclick={() => closeWindow()}
+    >
+      ×
+    </button>
+  </div>
+
+  <div class="shrink-0 px-5 pt-4">
+    <label class="text-sm text-base-content/50" for="watch-folder">Watch folder</label>
     <input
       id="watch-folder"
-      class="mb-3 mt-1 w-full rounded-xl border border-zinc-700/80 bg-zinc-800/90 p-3 text-zinc-100 outline-none transition-colors focus:border-pink-400/50"
+      class="mb-3 mt-1 w-full rounded-lg border border-base-300/80 bg-base-100/90 p-3 text-base-content outline-none transition-colors focus:border-primary/50"
       bind:value={config.watch_folder}
       placeholder="C:\Apps or /home/me/apps"
     />
     <div class={`grid gap-2 ${isLinux ? "grid-cols-2" : "grid-cols-3"}`}>
       {#if !isLinux}
-        <label class="text-sm text-zinc-500"
+        <label class="text-sm text-base-content/50"
           >Show<input
-            class="mt-1 w-full rounded-xl border border-zinc-700/80 bg-zinc-800/90 p-2 text-zinc-100 outline-none focus:border-pink-400/50"
+            class="mt-1 w-full rounded-lg border border-base-300/80 bg-base-100/90 p-2 text-base-content outline-none focus:border-primary/50"
             bind:value={config.toggle_hotkey}
           /></label
         >
       {/if}
-      <label class="text-sm text-zinc-500"
+      <label class="text-sm text-base-content/50"
         >Back<input
-          class="mt-1 w-full rounded-xl border border-zinc-700/80 bg-zinc-800/90 p-2 text-zinc-100 outline-none focus:border-pink-400/50"
+          class="mt-1 w-full rounded-lg border border-base-300/80 bg-base-100/90 p-2 text-base-content outline-none focus:border-primary/50"
           bind:value={config.back_hotkey}
         /></label
       >
-      <label class="text-sm text-zinc-500"
+      <label class="text-sm text-base-content/50"
         >Hide<input
-          class="mt-1 w-full rounded-xl border border-zinc-700/80 bg-zinc-800/90 p-2 text-zinc-100 outline-none focus:border-pink-400/50"
+          class="mt-1 w-full rounded-lg border border-base-300/80 bg-base-100/90 p-2 text-base-content outline-none focus:border-primary/50"
           bind:value={config.hide_hotkey}
         /></label
       >
     </div>
-    <p class="my-3 rounded-xl border border-zinc-800 bg-zinc-900/80 p-3 text-xs text-zinc-500">
+    <p class="my-3 rounded-lg border border-base-300 bg-base-200/80 p-3 text-xs text-base-content/50">
       {#if isLinux}
-        Linux: wake the launcher with a <strong class="text-zinc-400">desktop shortcut</strong> or
-        <strong class="text-zinc-400">system keyboard shortcut</strong> (see README). Back / Hide apply while the launcher is
+        Linux: wake the launcher with a <strong class="text-base-content/70">desktop shortcut</strong> or
+        <strong class="text-base-content/70">system keyboard shortcut</strong> (see README). Back / Hide apply while the launcher is
         focused.
       {:else}
         Back and hide keys apply while the launcher is focused. See README for assigning a shortcut to wake or focus the app on
@@ -104,51 +130,61 @@
     <label class="mt-2 flex items-center gap-2 text-sm"
       ><input type="checkbox" bind:checked={config.autostart} /> Autostart (reserved)</label
     >
-    <div class="mt-5 flex items-center justify-between">
-      <h2 class="font-bold text-zinc-100">Custom openers</h2>
-      <button
-        class="rounded-lg border border-pink-400/40 bg-zinc-800 px-3 py-1 text-sm text-pink-200 transition-colors hover:bg-zinc-700 hover:border-pink-300/60"
-        onclick={addOpener}>Add</button
-      >
-    </div>
-    <p class="mt-2 text-xs text-zinc-500">
-      On Linux, <code class="rounded border border-zinc-700 bg-zinc-800 px-1 text-zinc-400">.AppImage</code> files launch by
-      <strong>direct spawn</strong> when no row here matches their extension. Add a custom opener only if you need a different
-      command or wrapper.
-    </p>
-    {#each config.custom_openers as opener, i}
-      <div class="mt-3 rounded-2xl border border-zinc-700/70 bg-zinc-800/60 p-3">
-        <input
-          class="mb-2 w-full rounded-lg border border-zinc-700/80 bg-zinc-900/80 p-2 text-zinc-100 outline-none focus:border-pink-400/45"
-          placeholder="extensions: py,pyw"
-          value={opener.extensions.join(",")}
-          oninput={(e) =>
-            (opener.extensions = e.currentTarget.value
-              .split(",")
-              .map((x) => x.trim())
-              .filter(Boolean))}
-        />
-        <input
-          class="mb-2 w-full rounded-lg border border-zinc-700/80 bg-zinc-900/80 p-2 text-zinc-100 outline-none focus:border-pink-400/45"
-          placeholder="program"
-          bind:value={opener.program}
-        />
-        <input
-          class="w-full rounded-lg border border-zinc-700/80 bg-zinc-900/80 p-2 text-zinc-100 outline-none focus:border-pink-400/45"
-          placeholder="args"
-          value={opener.args.join(" ")}
-          oninput={(e) => (opener.args = e.currentTarget.value.split(" ").filter(Boolean))}
-        />
+  </div>
+
+  <section class="flex min-h-0 flex-1 flex-col px-5 pt-4">
+    <div class="shrink-0">
+      <div class="flex items-center justify-between">
+        <h2 class="font-bold text-base-content">Custom openers</h2>
         <button
-          class="mt-2 text-sm text-pink-400/90 transition-colors hover:text-pink-300"
-          onclick={() => removeOpener(i)}>Remove</button
+          class="rounded-md border border-primary/40 bg-base-100 px-3 py-1 text-sm text-primary transition-colors hover:border-primary/60 hover:bg-base-300"
+          onclick={addOpener}>Add</button
         >
       </div>
-    {/each}
+      <p class="mt-2 text-xs text-base-content/50">
+        On Linux, <code class="rounded border border-base-300 bg-base-100 px-1 text-base-content/70">.AppImage</code> files launch by
+        <strong>direct spawn</strong> when no row here matches their extension. Add a custom opener only if you need a different
+        command or wrapper.
+      </p>
+    </div>
+    <div class="mt-3 min-h-[13.5rem] flex-1 overflow-y-auto pr-1">
+      {#each config.custom_openers as opener, i}
+        <div class="rounded-lg border border-base-300/70 bg-base-100/60 p-3 {i > 0 ? 'mt-3' : ''}">
+          <input
+            class="mb-2 w-full rounded-md border border-base-300/80 bg-base-200/80 p-2 text-base-content outline-none focus:border-primary/45"
+            placeholder="extensions: py,pyw"
+            value={opener.extensions.join(",")}
+            oninput={(e) =>
+              (opener.extensions = e.currentTarget.value
+                .split(",")
+                .map((x) => x.trim())
+                .filter(Boolean))}
+          />
+          <input
+            class="mb-2 w-full rounded-md border border-base-300/80 bg-base-200/80 p-2 text-base-content outline-none focus:border-primary/45"
+            placeholder="program"
+            bind:value={opener.program}
+          />
+          <input
+            class="w-full rounded-md border border-base-300/80 bg-base-200/80 p-2 text-base-content outline-none focus:border-primary/45"
+            placeholder="args"
+            value={opener.args.join(" ")}
+            oninput={(e) => (opener.args = e.currentTarget.value.split(" ").filter(Boolean))}
+          />
+          <button
+            class="mt-2 text-sm text-primary/90 transition-colors hover:text-primary"
+            onclick={() => removeOpener(i)}>Remove</button
+          >
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <div class="shrink-0 px-5 pb-4 pt-3">
     <button
-      class="mt-5 w-full rounded-xl border-2 border-pink-400/70 bg-pink-500 py-3 font-black text-zinc-950 transition-colors hover:border-pink-300 hover:bg-pink-400"
+      class="w-full rounded-lg border-2 border-primary/70 bg-primary py-3 font-black text-primary-content transition-colors hover:border-primary hover:bg-primary/90"
       onclick={save}>Save</button
     >
-    <p class="mt-2 text-center text-sm text-pink-300/90">{message}</p>
+    <p class="mt-2 text-center text-sm text-primary/90">{message}</p>
   </div>
 </main>

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -1,16 +1,33 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
+  import { listen } from "@tauri-apps/api/event";
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import { defaultCustomOpeners } from "$lib/default-openers";
   import { onMount } from "svelte";
 
   type CustomOpener = { extensions: string[]; program: string; args: string[] };
+  type MonitorInfo = {
+    id: string;
+    name: string;
+    is_primary: boolean;
+    width: number;
+    height: number;
+    x: number;
+    y: number;
+  };
+  type PlatformCapabilities = {
+    session_type: string;
+    desktop: string;
+    launcher_screen_supported: boolean;
+    launcher_screen_note: string;
+  };
   type AppConfig = {
     watch_folder: string;
     toggle_hotkey: string;
     back_hotkey: string;
     hide_hotkey: string;
     show_at: string;
+    show_monitor_id: string;
     enable_in_fullscreen: boolean;
     autostart: boolean;
     custom_openers: CustomOpener[];
@@ -22,11 +39,13 @@
     back_hotkey: "`",
     hide_hotkey: "Esc",
     show_at: "mouse",
+    show_monitor_id: "",
     enable_in_fullscreen: false,
     autostart: false,
     custom_openers: defaultCustomOpeners(),
   });
-  let message = $state("");
+  let monitors = $state<MonitorInfo[]>([]);
+  let platform = $state<PlatformCapabilities | null>(null);
 
   const isLinux =
     (import.meta as ImportMeta & { env?: { TAURI_ENV_PLATFORM?: string } }).env?.TAURI_ENV_PLATFORM ===
@@ -38,7 +57,7 @@
   async function save() {
     try {
       await invoke("save_config", { config });
-      message = "Saved";
+      await closeWindow();
     } catch (e) {
       alert(String(e));
     }
@@ -58,13 +77,52 @@
   function removeOpener(i: number) {
     config.custom_openers = config.custom_openers.filter((_, idx) => idx !== i);
   }
+  function monitorLabel(m: MonitorInfo) {
+    const tag = m.is_primary ? " (primary)" : "";
+    return `${m.name}${tag}`;
+  }
+  function ensureFixedMonitor() {
+    if (config.show_at !== "fixed" || config.show_monitor_id || monitors.length === 0) return;
+    const primary = monitors.find((m) => m.is_primary) ?? monitors[0];
+    config = { ...config, show_monitor_id: primary.id };
+  }
+  async function refreshMonitors() {
+    monitors = await invoke("list_monitors");
+    if (
+      config.show_at === "fixed" &&
+      config.show_monitor_id &&
+      !monitors.some((m) => m.id === config.show_monitor_id)
+    ) {
+      config = { ...config, show_monitor_id: "" };
+    }
+    ensureFixedMonitor();
+  }
   onMount(() => {
-    void load();
+    void (async () => {
+      platform = await invoke("get_platform_capabilities");
+      await load();
+      await refreshMonitors();
+    })();
+    const unsubs: (() => void)[] = [];
+    void listen<MonitorInfo[]>("monitors-changed", (event) => {
+      monitors = event.payload;
+      if (
+        config.show_at === "fixed" &&
+        config.show_monitor_id &&
+        !monitors.some((m) => m.id === config.show_monitor_id)
+      ) {
+        config = { ...config, show_monitor_id: "" };
+      }
+      ensureFixedMonitor();
+    }).then((u) => unsubs.push(u));
+    return () => {
+      for (const u of unsubs) u();
+    };
   });
 </script>
 
 <main
-  class="box-border flex h-[100dvh] flex-col overflow-hidden rounded-lg border-2 border-primary/25 bg-base-100 text-base-content"
+  class="box-border flex h-[100dvh] flex-col overflow-hidden rounded-lg border-2 border-primary/25 bg-base-100 text-base-content scheme-dark"
 >
   <div class="flex shrink-0 items-center border-b border-base-300/70">
     <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -84,7 +142,7 @@
     </button>
   </div>
 
-  <div class="shrink-0 px-5 pt-4">
+  <div class="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 pt-4 pb-4">
     <label class="text-sm text-base-content/50" for="watch-folder">Watch folder</label>
     <input
       id="watch-folder"
@@ -92,6 +150,47 @@
       bind:value={config.watch_folder}
       placeholder="C:\Apps or /home/me/apps"
     />
+    <fieldset class="mb-3 rounded-lg border border-base-300/70 p-3">
+      <legend class="px-1 text-sm text-base-content/50">Launcher screen</legend>
+      {#if platform && !platform.launcher_screen_supported}
+        <p class="mb-3 rounded-lg border border-warning/40 bg-base-200/80 p-3 text-xs text-base-content/70">
+          {platform.launcher_screen_note}
+          <span class="mt-1 block text-base-content/50">
+            Session: {platform.session_type} · Desktop: {platform.desktop}
+          </span>
+        </p>
+      {/if}
+      <div class="space-y-2 text-sm">
+        <label class="flex items-center gap-2">
+          <input type="radio" bind:group={config.show_at} value="mouse" />
+          Follow mouse cursor
+        </label>
+        <label class="flex items-center gap-2">
+          <input type="radio" bind:group={config.show_at} value="focus" />
+          Follow focused window
+        </label>
+        <label class="flex items-center gap-2">
+          <input type="radio" bind:group={config.show_at} value="fixed" onchange={ensureFixedMonitor} />
+          Fixed screen
+        </label>
+      </div>
+      {#if config.show_at === "fixed"}
+        <label class="mt-3 block text-sm text-base-content/50" for="show-monitor">Screen</label>
+        <select
+          id="show-monitor"
+          class="mt-1 w-full rounded-lg border border-base-300/80 bg-base-200/80 p-2 text-base-content outline-none transition-colors focus:border-primary/50"
+          bind:value={config.show_monitor_id}
+        >
+          {#if monitors.length === 0}
+            <option value="">No screens detected</option>
+          {:else}
+            {#each monitors as monitor (monitor.id)}
+              <option value={monitor.id}>{monitorLabel(monitor)}</option>
+            {/each}
+          {/if}
+        </select>
+      {/if}
+    </fieldset>
     <div class={`grid gap-2 ${isLinux ? "grid-cols-2" : "grid-cols-3"}`}>
       {#if !isLinux}
         <label class="text-sm text-base-content/50"
@@ -130,10 +229,8 @@
     <label class="mt-2 flex items-center gap-2 text-sm"
       ><input type="checkbox" bind:checked={config.autostart} /> Autostart (reserved)</label
     >
-  </div>
 
-  <section class="flex min-h-0 flex-1 flex-col px-5 pt-4">
-    <div class="shrink-0">
+    <section class="mt-5">
       <div class="flex items-center justify-between">
         <h2 class="font-bold text-base-content">Custom openers</h2>
         <button
@@ -146,45 +243,46 @@
         <strong>direct spawn</strong> when no row here matches their extension. Add a custom opener only if you need a different
         command or wrapper.
       </p>
-    </div>
-    <div class="mt-3 min-h-[13.5rem] flex-1 overflow-y-auto pr-1">
-      {#each config.custom_openers as opener, i}
-        <div class="rounded-lg border border-base-300/70 bg-base-100/60 p-3 {i > 0 ? 'mt-3' : ''}">
-          <input
-            class="mb-2 w-full rounded-md border border-base-300/80 bg-base-200/80 p-2 text-base-content outline-none focus:border-primary/45"
-            placeholder="extensions: py,pyw"
-            value={opener.extensions.join(",")}
-            oninput={(e) =>
-              (opener.extensions = e.currentTarget.value
-                .split(",")
-                .map((x) => x.trim())
-                .filter(Boolean))}
-          />
-          <input
-            class="mb-2 w-full rounded-md border border-base-300/80 bg-base-200/80 p-2 text-base-content outline-none focus:border-primary/45"
-            placeholder="program"
-            bind:value={opener.program}
-          />
-          <input
-            class="w-full rounded-md border border-base-300/80 bg-base-200/80 p-2 text-base-content outline-none focus:border-primary/45"
-            placeholder="args"
-            value={opener.args.join(" ")}
-            oninput={(e) => (opener.args = e.currentTarget.value.split(" ").filter(Boolean))}
-          />
-          <button
-            class="mt-2 text-sm text-primary/90 transition-colors hover:text-primary"
-            onclick={() => removeOpener(i)}>Remove</button
-          >
-        </div>
-      {/each}
-    </div>
-  </section>
+      <div class="mt-3 space-y-3">
+        {#each config.custom_openers as opener, i}
+          <div class="rounded-lg border border-base-300/70 bg-base-100/60 p-3">
+            <input
+              class="mb-2 w-full rounded-md border border-base-300/80 bg-base-200/80 p-2 text-base-content outline-none focus:border-primary/45"
+              placeholder="extensions: py,pyw"
+              value={opener.extensions.join(",")}
+              oninput={(e) =>
+                (opener.extensions = e.currentTarget.value
+                  .split(",")
+                  .map((x) => x.trim())
+                  .filter(Boolean))}
+            />
+            <input
+              class="mb-2 w-full rounded-md border border-base-300/80 bg-base-200/80 p-2 text-base-content outline-none focus:border-primary/45"
+              placeholder="program"
+              bind:value={opener.program}
+            />
+            <input
+              class="w-full rounded-md border border-base-300/80 bg-base-200/80 p-2 text-base-content outline-none focus:border-primary/45"
+              placeholder="args"
+              value={opener.args.join(" ")}
+              oninput={(e) => (opener.args = e.currentTarget.value.split(" ").filter(Boolean))}
+            />
+            <button
+              class="mt-2 text-sm text-primary/90 transition-colors hover:text-primary"
+              onclick={() => removeOpener(i)}>Remove</button
+            >
+          </div>
+        {/each}
+      </div>
+    </section>
+  </div>
 
-  <div class="shrink-0 px-5 pb-4 pt-3">
+  <div
+    class="relative z-20 shrink-0 border-t border-base-300/70 bg-base-100 px-5 py-4 shadow-[0_-12px_24px_oklch(20%_0_0/0.85)]"
+  >
     <button
       class="w-full rounded-lg border-2 border-primary/70 bg-primary py-3 font-black text-primary-content transition-colors hover:border-primary hover:bg-primary/90"
       onclick={save}>Save</button
     >
-    <p class="mt-2 text-center text-sm text-primary/90">{message}</p>
   </div>
 </main>


### PR DESCRIPTION
## Summary

- Add launcher screen placement settings: mouse cursor, focused window monitor, or fixed monitor ID
- Backend monitor listing with live `monitors-changed` sync; `get_platform_capabilities` for Wayland caveats
- Setup UI for screen selection; README and AGENTS.md cross-platform guidance
- Builds on #33 (xianii theme/setup UI); merge that PR first or this PR includes both commits

## Test plan

- [ ] `npm run check` passes
- [ ] `cargo check` (in `src-tauri/`) passes
- [ ] Setup shows monitor list and show-at options (mouse / focus / fixed)
- [ ] Launcher appears on the configured monitor on X11
- [ ] Wayland limitation is surfaced in setup via platform capabilities
- [ ] Monitor list refreshes when displays are connected/disconnected


Made with [Cursor](https://cursor.com)